### PR TITLE
updating typo in notebooks/Spaghetti_Pointpatterns_Empirical.ipynb

### DIFF
--- a/notebooks/Spaghetti_Pointpatterns_Empirical.ipynb
+++ b/notebooks/Spaghetti_Pointpatterns_Empirical.ipynb
@@ -303,7 +303,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### **  The original coordinates of the schools need to be extracted from `school_points`"
+    "### **  The original coordinates of the crimes need to be extracted from `crime_points`"
    ]
   },
   {
@@ -327,7 +327,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Snapped school locations"
+    "## Snapped crime locations"
    ]
   },
   {


### PR DESCRIPTION
addresses #146 

correcting "schools" --> "crimes" typo