### PR TITLE
Refactor element as gdf

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -35,8 +35,6 @@ spaghetti.Network
     spaghetti.network.Network.loadnetwork
 
 
-.. _network_api:
-
 spaghetti.PointPattern
 ----------------------
 
@@ -46,8 +44,6 @@ spaghetti.PointPattern
    spaghetti.network.PointPattern
 
 
-.. _network_api:
-
 spaghetti.SimulatedPointPattern
 -------------------------------
 
@@ -56,8 +52,6 @@ spaghetti.SimulatedPointPattern
    
     spaghetti.network.SimulatedPointPattern
 
-
-.. _network_api:
 
 spaghetti
 ---------

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -1679,8 +1679,12 @@ def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
             return points
     
     # edges
-
-
+    edges = util._edges_as_gdf(net, points, id_col=id_col, geom_col=geom_col)
+    
+    if nodes_for_edges:
+        return edges
+    else:
+        return points, edges
 
 
 class PointPattern():

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -1521,7 +1521,7 @@ class Network:
             
         return self
 
-@requires('geopandas', 'shapely')
+
 def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
                    snapped=False, id_col='id', geom_col='geometry'):
     """Return a GeoDataFrame of network elements. This can be (a) the
@@ -1670,8 +1670,8 @@ def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
 
     # nodes/points
     if nodes or nodes_for_edges or pp_name:
-        util._points_as_gdf(net, nodes, nodes_for_edges, pp_name,
-                            snapped, id_col=id_col, geom_col=geom_col)
+        points = util._points_as_gdf(net, nodes, nodes_for_edges, pp_name,
+                                     snapped, id_col=id_col, geom_col=geom_col)
         
         # return points geodataframe if edges not specified or
         # if extracting `PointPattern` points

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -1577,6 +1577,11 @@ def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
         as a simple `geopandas.GeoDataFrame` of `shapely.LineString`
         objects with an `id` column and `geometry` column.
     
+    Notes
+    -----
+    
+    The function requires `geopandas`
+    
     Examples
     --------
     
@@ -1604,6 +1609,8 @@ def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
     POINT (727919.2473619275 875942.4986759046)
     
     """
+    
+    '''
     # need nodes place holder to create network segment LineStrings
     # even if only network edges are desired.
     nodes_for_edges = False
@@ -1651,6 +1658,29 @@ def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
         return edges
     else:
         return points, edges
+    '''
+
+
+
+    # need nodes place holder to create network segment LineStrings
+    # even if only network edges are desired.
+    nodes_for_edges = False
+    if edges and not nodes:
+        nodes_for_edges = True
+
+    # nodes/points
+    if nodes or nodes_for_edges or pp_name:
+        util._points_as_gdf(net, nodes, nodes_for_edges, pp_name,
+                            snapped, id_col=id_col, geom_col=geom_col)
+        
+        # return points geodataframe if edges not specified or
+        # if extracting `PointPattern` points
+        if not edges or pp_name:
+            return points
+    
+    # edges
+
+
 
 
 class PointPattern():

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -3,18 +3,10 @@ import copy, os, pickle
 from warnings import warn
 
 import numpy as np
-try:
-    import geopandas as gpd
-    from shapely.geometry import Point, LineString
-except ImportError:
-    err_msg = 'geopandas/shapely not available. '\
-              + 'Some functionality will be disabled.'
-    warn(err_msg)
 
 from .analysis import NetworkG, NetworkK, NetworkF
 from . import util
 from libpysal import cg, examples, weights
-from libpysal.common import requires
 try:
     from libpysal import open
 except ImportError:

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -1,6 +1,5 @@
 from collections import defaultdict, OrderedDict
 import copy, os, pickle
-from warnings import warn
 
 import numpy as np
 

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -1581,36 +1581,6 @@ def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
     
     This function requires `geopandas`.
     
-    Examples
-    --------
-    
-    >>> try:
-    ...     import geopandas
-    ... except ImportError:
-    ...     raise ImportError('`geopandas` not available')
-    >>> import spaghetti as spgh
-    >>> streets_file = examples.get_path('streets.shp')
-    >>> ntw = spgh.Network(streets_file)
-    >>> nodes, edges = spgh.element_as_gdf(ntw, nodes=True, edges=True)
-    
-    >>> print(nodes.loc[(nodes['id'] == 0), 'geometry'].squeeze())
-    POINT (728368.04762 877125.89535)
-    
-    >>> print(edges.loc[(edges['id'] == (0,1)), 'geometry'].squeeze())
-    LINESTRING (728368.04762 877125.89535, 728368.13931 877023.27186)
-    
-    >>> obs_type = 'crimes'
-    >>> in_data = examples.get_path('%s.shp' % obs_type)
-    >>> ntw.snapobservations(in_data, obs_type)
-    >>> obs = spgh.element_as_gdf(ntw, pp_name=obs_type)
-    >>> print(obs.loc[(obs['id'] == 0), 'geometry'].squeeze())
-    POINT (727913.0000000029 875720.9999999977)
-    
-    >>> snp_obs = spgh.element_as_gdf(ntw, pp_name=obs_type,
-    ...                               snapped=True)
-    >>> print(snp_obs.loc[(snp_obs['id'] == 0), 'geometry'].squeeze())
-    POINT (727919.2473619275 875942.4986759046)
-    
     """
     
     # need nodes place holder to create network segment LineStrings

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -84,7 +84,7 @@ class Network:
         tuples of graph edge ids.
     
     graph_lengths : dict
-        Keys are the graph edge ids (tuple). Values are the graph edge lenght
+        Keys are the graph edge ids (tuple). Values are the graph edge length
         (float).
     
     Examples

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -1580,7 +1580,7 @@ def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
     Notes
     -----
     
-    The function requires `geopandas`
+    This function requires `geopandas`
     
     Examples
     --------

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -1610,58 +1610,6 @@ def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
     
     """
     
-    '''
-    # need nodes place holder to create network segment LineStrings
-    # even if only network edges are desired.
-    nodes_for_edges = False
-    if edges and not nodes:
-        nodes_for_edges = True
-    
-    # nodes
-    if nodes or nodes_for_edges:
-        pts_dict = net.node_coords
-    
-    # raw point pattern
-    if pp_name and not snapped:
-        try: 
-            pp_pts = net.pointpatterns[pp_name].points
-        except KeyError:
-            err_msg = 'Available point patterns are {}'
-            raise KeyError(err_msg.format(list(net.pointpatterns.keys())))
-            
-        n_pp_pts = range(len(pp_pts))
-        pts_dict = {point:pp_pts[point]['coordinates'] for point in n_pp_pts}
-    
-    # snapped point pattern
-    elif pp_name and snapped:
-        pts_dict = net.pointpatterns[pp_name].snapped_coordinates
-    
-    # instantiate geopandas.GeoDataFrame
-    pts_list = list(pts_dict.items())
-    points = gpd.GeoDataFrame(pts_list, columns=[id_col, geom_col])
-    points.geometry = points.geometry.apply(lambda p: Point(p))
-    
-    # return points geodataframe if edges not specified or
-    # if extracting `PointPattern` points
-    if not edges or pp_name:
-        return points
-    
-    # edges
-    edges = {}
-    for (node1_id, node2_id) in net.edges:
-        node1 = points.loc[(points[id_col] == node1_id), geom_col].squeeze()
-        node2 = points.loc[(points[id_col] == node2_id), geom_col].squeeze()
-        edges[(node1_id, node2_id)] = LineString((node1, node2))
-    edges = gpd.GeoDataFrame(list(edges.items()), columns=[id_col, geom_col])
-    
-    if nodes_for_edges:
-        return edges
-    else:
-        return points, edges
-    '''
-
-
-
     # need nodes place holder to create network segment LineStrings
     # even if only network edges are desired.
     nodes_for_edges = False

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -1584,6 +1584,10 @@ def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
     Examples
     --------
     
+    >>> try:
+    ...     import geopandas
+    ... except ImportError:
+    ...     raise ImportError('`geopandas` not available')
     >>> import spaghetti as spgh
     >>> streets_file = examples.get_path('streets.shp')
     >>> ntw = spgh.Network(streets_file)

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -1580,7 +1580,7 @@ def element_as_gdf(net, nodes=False, edges=False, pp_name=None,
     Notes
     -----
     
-    This function requires `geopandas`
+    This function requires `geopandas`.
     
     Examples
     --------

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -10,6 +10,7 @@ except ImportError:
     warn(err_msg)
 
 import numpy as np
+from warnings import warn
 
 
 def compute_length(v0, v1):

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -392,7 +392,19 @@ def snap_points_on_segments(points, segments):
 def _points_as_gdf(net, nodes, nodes_for_edges, pp_name, snapped,
                    id_col=None, geom_col=None):
     """
-    Internal function for `spaghetti.element_as_gdf()`
+    Internal function for returning a point geopandas.GeoDataFrame
+    called from within `spaghetti.element_as_gdf()`. 
+    
+    Parameters
+    ----------
+    
+    
+    
+    Notes
+    -----
+    
+    1. See `spaghetti.element_as_gdf()` for description of arguments
+    2. This function requires `geopandas`
     """
     
     # nodes

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -398,13 +398,34 @@ def _points_as_gdf(net, nodes, nodes_for_edges, pp_name, snapped,
     Parameters
     ----------
     
+    nodes_for_edges : bool
+        Flag for points being an object returned [False] or for merely
+        creating network edges [True]. Set from within the parent
+        function (`spaghetti.element_as_gdf()`). 
     
+    Raises
+    ------
+    
+    KeyError
+        In order to extract a `PointPattern` it must already be a part
+        of the `spaghetti.Network` object. This exception is raised
+        when a `PointPattern` is being extracted that does not exist
+        within the `spaghetti.Network` object.
+    
+    Returns
+    -------
+    
+    points : geopandas.GeoDataFrame
+        Network point elements (either nodes or `PointPattern` points)
+        as a simple `geopandas.GeoDataFrame` of `shapely.Point` objects
+        with an `id` column and `geometry` column.
     
     Notes
     -----
     
     1. See `spaghetti.element_as_gdf()` for description of arguments
     2. This function requires `geopandas`
+    
     """
     
     # nodes
@@ -432,8 +453,4 @@ def _points_as_gdf(net, nodes, nodes_for_edges, pp_name, snapped,
     points.geometry = points.geometry.apply(lambda p: Point(p))
     
     return points
-    
-    
-    
-    
-    
+

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -387,3 +387,41 @@ def snap_points_on_segments(points, segments):
                 
     return p2s
 
+
+@requires('geopandas', 'shapely')
+def _points_as_gdf(net, nodes, nodes_for_edges, pp_name, snapped,
+                   id_col=None, geom_col=None):
+    """
+    Internal function for `spaghetti.element_as_gdf()`
+    """
+    
+    # nodes
+    if nodes or nodes_for_edges:
+        pts_dict = net.node_coords
+    
+    # raw point pattern
+    if pp_name and not snapped:
+        try: 
+            pp_pts = net.pointpatterns[pp_name].points
+        except KeyError:
+            err_msg = 'Available point patterns are {}'
+            raise KeyError(err_msg.format(list(net.pointpatterns.keys())))
+            
+        n_pp_pts = range(len(pp_pts))
+        pts_dict = {point:pp_pts[point]['coordinates'] for point in n_pp_pts}
+    
+    # snapped point pattern
+    elif pp_name and snapped:
+        pts_dict = net.pointpatterns[pp_name].snapped_coordinates
+    
+    # instantiate geopandas.GeoDataFrame
+    pts_list = list(pts_dict.items())
+    points = gpd.GeoDataFrame(pts_list, columns=[id_col, geom_col])
+    points.geometry = points.geometry.apply(lambda p: Point(p))
+    
+    return points
+    
+    
+    
+    
+    

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -454,3 +454,36 @@ def _points_as_gdf(net, nodes, nodes_for_edges, pp_name, snapped,
     
     return points
 
+
+@requires('geopandas', 'shapely')
+def _edges_as_gdf(net, points, id_col=None, geom_col=None):
+    """
+    Internal function for returning a edges geopandas.GeoDataFrame
+    called from within `spaghetti.element_as_gdf()`. 
+    
+    Returns
+    -------
+    
+    points : geopandas.GeoDataFrame
+        Network point elements (either nodes or `PointPattern` points)
+        as a simple `geopandas.GeoDataFrame` of `shapely.Point` objects
+        with an `id` column and `geometry` column.
+    
+    Notes
+    -----
+    
+    1. See `spaghetti.element_as_gdf()` for description of arguments
+    2. This function requires `geopandas`
+    
+    """
+    
+    # edges
+    edges = {}
+    for (node1_id, node2_id) in net.edges:
+        node1 = points.loc[(points[id_col] == node1_id), geom_col].squeeze()
+        node2 = points.loc[(points[id_col] == node2_id), geom_col].squeeze()
+        edges[(node1_id, node2_id)] = LineString((node1, node2))
+    edges = gpd.GeoDataFrame(list(edges.items()), columns=[id_col, geom_col])
+    
+    return edges
+

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -393,7 +393,7 @@ def _points_as_gdf(net, nodes, nodes_for_edges, pp_name, snapped,
                    id_col=None, geom_col=None):
     """
     Internal function for returning a point geopandas.GeoDataFrame
-    called from within `spaghetti.element_as_gdf()`. 
+    called from within `spaghetti.element_as_gdf()`.
     
     Parameters
     ----------
@@ -401,7 +401,7 @@ def _points_as_gdf(net, nodes, nodes_for_edges, pp_name, snapped,
     nodes_for_edges : bool
         Flag for points being an object returned [False] or for merely
         creating network edges [True]. Set from within the parent
-        function (`spaghetti.element_as_gdf()`). 
+        function (`spaghetti.element_as_gdf()`).
     
     Raises
     ------
@@ -459,7 +459,7 @@ def _points_as_gdf(net, nodes, nodes_for_edges, pp_name, snapped,
 def _edges_as_gdf(net, points, id_col=None, geom_col=None):
     """
     Internal function for returning a edges geopandas.GeoDataFrame
-    called from within `spaghetti.element_as_gdf()`. 
+    called from within `spaghetti.element_as_gdf()`.
     
     Returns
     -------

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -1,4 +1,14 @@
 from libpysal import cg
+from libpysal.common import requires
+
+try:
+    import geopandas as gpd
+    from shapely.geometry import Point, LineString
+except ImportError:
+    err_msg = 'geopandas/shapely not available. '\
+              + 'Some functionality will be disabled.'
+    warn(err_msg)
+
 import numpy as np
 
 
@@ -376,3 +386,4 @@ def snap_points_on_segments(points, segments):
                 p2s[ptIdx] = (closest, p2b)
                 
     return p2s
+

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from libpysal import cg
 from libpysal.common import requires
 
@@ -10,7 +12,6 @@ except ImportError:
     warn(err_msg)
 
 import numpy as np
-from warnings import warn
 
 
 def compute_length(v0, v1):


### PR DESCRIPTION
Addressing [this comment](https://github.com/pysal/spaghetti/issues/162#issuecomment-441496008) in Issue #162.

- converting `element_as_gdf()` in `network.py` into a parent function which calls `util._points_as_gdf()` and `util._edges_as_gdf()`

This PR will move the `@requires` decorator out of `network.py` which ***should*** correct the issue `numydocs` is having with the creation of `.rst` files.