### PR TITLE
bump from rc to stable

### DIFF
--- a/spaghetti/__init__.py
+++ b/spaghetti/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2rc1"
+__version__ = "1.2"
 """
 :mod:`spaghetti` --- Spatial Graphs: Networks, Topology, & Inference
 ====================================================================


### PR DESCRIPTION
The justification for this PR is: 
- bump version from `v1.2rc1` (release candidate) to stable `v1.2`