### PR TITLE
bumping down geopandas requirement to 0.3.0

### DIFF
--- a/requirements_plus.txt
+++ b/requirements_plus.txt
@@ -1,1 +1,1 @@
-geopandas>=0.4.1
+geopandas>=0.3.0


### PR DESCRIPTION
`geopandas v0.3.0` supports more platforms.
