### PR TITLE
Switch snapping to Rtree package?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 scipy>=0.11
 numpy>=1.3
 pandas
-libpysal
 esda
 rtree

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.3
 pandas
 libpysal
 esda
+rtree

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -480,7 +480,8 @@ def snap_points_to_links(points, links):
         # Find all links with bounding boxes that intersect
         # a query rectangle centered on the point with sides
         # of length dmin * dmin
-        candidates = [cand.object for cand in rtree.intersection([x0, y0, x1, y1], objects=True)]
+        rtree_lookup = rtree.intersection([x0, y0, x1, y1]
+        candidates = [cand.object for cand in rtree_lookup, objects=True)]
         dmin += SMALL
         dmin2 = dmin * dmin
         

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -6,6 +6,7 @@ from libpysal.common import requires
 try:
     import geopandas as gpd
     from shapely.geometry import Point, LineString
+    from rtree import Rtree
 except ImportError:
     err_msg = 'geopandas/shapely not available. '\
               + 'Some functionality will be disabled.'
@@ -421,7 +422,7 @@ def snap_points_to_links(points, links):
     """
     
     # instantiate an rtree
-    rtree = cg.Rtree()
+    rtree = Rtree()
     # set the smallest possible float epsilon on machine
     SMALL = np.finfo(float).eps
     
@@ -429,7 +430,7 @@ def snap_points_to_links(points, links):
     vertex_2_link = {}
     
     # iterate over network links
-    for link in links:
+    for i,link in enumerate(links):
         
         # extract network link (x,y) vertex coordinates
         head, tail = link.vertices
@@ -452,12 +453,9 @@ def snap_points_to_links(points, links):
         bx1 += SMALL
         by1 += SMALL
         
-        # create a rectangle
-        rect = cg.Rect(bx0, by0, bx1, by1)
-        
         # insert the network link and its associated
         # rectangle into the rtree
-        rtree.insert(link, rect)
+        rtree.insert(i, (bx0, by0, bx1, by1), obj=link)
         
     # build a KDtree on link vertices
     kdtree = cg.KDTree(list(vertex_2_link.keys()))
@@ -482,7 +480,7 @@ def snap_points_to_links(points, links):
         # Find all links with bounding boxes that intersect
         # a query rectangle centered on the point with sides
         # of length dmin * dmin
-        candidates = [cand for cand in rtree.intersection([x0, y0, x1, y1])]
+        candidates = [cand.object for cand in rtree.intersection([x0, y0, x1, y1], objects=True)]
         dmin += SMALL
         dmin2 = dmin * dmin
         

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -480,8 +480,8 @@ def snap_points_to_links(points, links):
         # Find all links with bounding boxes that intersect
         # a query rectangle centered on the point with sides
         # of length dmin * dmin
-        rtree_lookup = rtree.intersection([x0, y0, x1, y1]
-        candidates = [cand.object for cand in rtree_lookup, objects=True)]
+        rtree_lookup = rtree.intersection([x0, y0, x1, y1], objects=True)
+        candidates = [cand.object for cand in rtree_lookup]
         dmin += SMALL
         dmin2 = dmin * dmin
         

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -2,11 +2,11 @@ from warnings import warn
 
 from libpysal import cg
 from libpysal.common import requires
+from rtree import Rtree
 
 try:
     import geopandas as gpd
     from shapely.geometry import Point, LineString
-    from rtree import Rtree
 except ImportError:
     err_msg = 'geopandas/shapely not available. '\
               + 'Some functionality will be disabled.'


### PR DESCRIPTION
This tests out switching the Rtree implementation to that provided by `libspatialindex`. This is the only place that Spaghetti uses an Rtree. This resolves issues reported by [libpysal#126](https://github.com/pysal/libpysal/issues/126) in the downstream location, rather than upstream with the rtree package. Given the existing soft dependencies on shapely & geopandas in the module, I think this might be a simpler fix to consider.