### PR TITLE
remove geopandas version stipulation

### DIFF
--- a/requirements_plus.txt
+++ b/requirements_plus.txt
@@ -1,1 +1,1 @@
-geopandas>=0.3.0
+geopandas


### PR DESCRIPTION
removing `geopandas` version stipulation (>=0.3.0) from `requirements_plus.txt`.