### PR TITLE
adding CoC link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Support
 
 If you are having issues, please [create an issue](https://github.com/pysal/spaghetti/issues) or talk to us in the [gitter room](https://gitter.im/pysal/spaghetti).
 
+
+Code of Conduct
+---------------
+
+As a PySAL-federated project, `spaghetti` follows the [Code of Conduct](https://github.com/pysal/governance/blob/master/conduct/code_of_conduct.rst) under the [PySAL governance model](https://github.com/pysal/governance).
+
+
 License
 -------
 


### PR DESCRIPTION
This PR adds Code of Conduct information from PySAL to `README.md`.