### PR TITLE
point pattern --> network error message

### DIFF
--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -413,7 +413,7 @@ class Network:
         is_libpysal_chains = False
         supported_iterables = ["list", "tuple", "numpy.ndarray"]
         # type error message
-        msg = "'%s' not supported for point pattern instantiation."
+        msg = "'%s' not supported for network instantiation."
 
         # set appropriate geometries
         if in_dtype == "str":


### PR DESCRIPTION
This PR fixes an [incorrect error message](https://github.com/pysal/spaghetti/blob/6f216e5b4d338819eb61e6c133e16de3c55c009f/spaghetti/network.py#L416) in `network.py`.