### PR TITLE
mention the pysal/notebook project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Spaghetti is an open-source Python library for the analysis of network-based spa
 
 Examples
 -----------
-The following examples can be launched individually as interactive binders from the links on their respective pages. Additional examples can be found in the [Tutorials](https://pysal.org/spaghetti/tutorials.html) section of the documentation.
+The following examples can be launched individually as interactive binders from the links on their respective pages. Additional examples can be found in the [Tutorials](https://pysal.org/spaghetti/tutorials.html) section of the documentation. See the [`pysal/notebooks`](http://pysal.org/notebooks) project for a [`jupyter-book`](https://github.com/choldgraf/jupyter-book) version of this repository.
 * [Network Representation](https://pysal.org/spaghetti/notebooks/Basic_spaghetti_tutorial.html)
 * [Spatial Network Analysis](https://pysal.org/spaghetti/notebooks/Advanced_spaghetti_tutorial.html)
 * [Optimal Facility Location](https://pysal.org/spaghetti/notebooks/Use_case-facility_location.html)


### PR DESCRIPTION
This PR adds a link to the pysal/notebook project, based that in [`splot`](https://github.com/pysal/splot/pull/97/commits/c0ae8cd4fa665c24132c87afe7ef7ffd739a987e).