### PR TITLE
pushing fix for environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: notebooks-environment
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.7
   - geopandas
   - descartes
   - rtree
@@ -10,6 +10,7 @@ dependencies:
   - pulp
   - esda
   - matplotlib
+  - matplotlib_scalebar
   - watermark
   - seaborn
   - pip


### PR DESCRIPTION
* Python 3.8 doesn't appear to be playing nicely within the [`binder`](https://mybinder.org/v2/gh/pysal/spaghetti/master) environment, so bumping back down to 3.7 for now
* Also adding `matplotlib_scalebar` to `environment.yml`.
