### PR TITLE
fixing conda-forge failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,12 @@ from distutils.command.build_py import build_py
 
 package = "spaghetti"
 
+# This check resolves conda-forge build failures
+# See the link below for original solution
+# https://github.com/pydata/xarray/pull/2643/files#diff-2eeaed663bd0d25b7e608891384b7298R29-R30
+needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
+setup_requires = ["pytest-runner"] if needs_pytest else []
+
 # Get __version__ from package/__init__.py
 with open(package + "/__init__.py", "r") as f:
     exec(f.readline())
@@ -66,7 +72,7 @@ def setup_package():
         download_url="https://pypi.org/project/" + package,
         maintainer="James D. Gaboardi",
         maintainer_email="jgaboardi@gmail.com",
-        setup_requires=["pytest-runner"],
+        setup_requires=setup_requires,
         tests_require=["pytest"],
         keywords="spatial statistics, networks, graphs",
         classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from setuptools import setup
 from distutils.command.build_py import build_py
-
+from setuptools import setup
+import sys
 
 package = "spaghetti"
 


### PR DESCRIPTION
This PR attempts to resolve a [`conda-forge` build failure](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=124481&view=logs&j=e018f978-a0ce-53fb-9fb6-ffd586bfca01&t=5c69329b-d947-5705-66b5-610e0963c1aa&l=490) stemming from the [`pytest-runner` requirement in setup.py]().

See also, conda-forge/spaghetti-feedstock#13, pydata/xarray#2641, pydata/xarray#2643