### PR TITLE
Add black check GHA-CI 

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,6 +31,8 @@
        - shell: bash -l {0}
          run: conda list
        - shell: bash -l {0}
+         run: python -m black spaghetti --check
+       - shell: bash -l {0}
          run: py.test -v spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
        - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})
          uses: codecov/codecov-action@v1

--- a/ci/36-GIT-PLUS.yaml
+++ b/ci/36-GIT-PLUS.yaml
@@ -10,10 +10,11 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov
   # optional
   - geopandas>=0.7.0
   # required

--- a/ci/36-GIT.yaml
+++ b/ci/36-GIT.yaml
@@ -10,10 +10,11 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov
   # required
   - pip
   - pip:

--- a/ci/36-PYPI-PLUS.yaml
+++ b/ci/36-PYPI-PLUS.yaml
@@ -11,9 +11,10 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov
   # optional
   - geopandas>=0.7.0

--- a/ci/36-PYPI.yaml
+++ b/ci/36-PYPI.yaml
@@ -11,7 +11,8 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov

--- a/ci/37-GIT-PLUS.yaml
+++ b/ci/37-GIT-PLUS.yaml
@@ -10,10 +10,11 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov
   # optional
   - geopandas>=0.7.0
   # required

--- a/ci/37-GIT.yaml
+++ b/ci/37-GIT.yaml
@@ -10,10 +10,11 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov
   # required
   - pip
   - pip:

--- a/ci/37-PYPI-PLUS.yaml
+++ b/ci/37-PYPI-PLUS.yaml
@@ -11,9 +11,10 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov
   # optional
   - geopandas>=0.7.0

--- a/ci/37-PYPI.yaml
+++ b/ci/37-PYPI.yaml
@@ -11,7 +11,8 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov

--- a/ci/38-GIT-PLUS.yaml
+++ b/ci/38-GIT-PLUS.yaml
@@ -10,10 +10,11 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov
   # optional
   - geopandas>=0.7.0
   # required

--- a/ci/38-GIT.yaml
+++ b/ci/38-GIT.yaml
@@ -10,10 +10,11 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov
   # required
   - pip
   - pip:

--- a/ci/38-PYPI-PLUS.yaml
+++ b/ci/38-PYPI-PLUS.yaml
@@ -11,9 +11,10 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov
   # optional
   - geopandas>=0.7.0

--- a/ci/38-PYPI.yaml
+++ b/ci/38-PYPI.yaml
@@ -11,7 +11,8 @@ dependencies:
   - rtree
   - scipy>=1.0
   - watermark
-  # testing
+  # testing/formatting
+  - black
+  - codecov
   - pytest
   - pytest-cov
-  - codecov


### PR DESCRIPTION
Adding a check for `black` code formatting to the GHA-CI (`unittests.yml`).