### PR TITLE
updating test_nearest_neighbor_distances()

### DIFF
--- a/spaghetti/tests/network_unittest_classes.py
+++ b/spaghetti/tests/network_unittest_classes.py
@@ -634,8 +634,8 @@ class TestNetworkPointPattern(unittest.TestCase):
             self.ntw.nearestneighbordistances("i_should_not_exist")
         nnd1 = self.ntw.nearestneighbordistances(schools)
         nnd2 = self.ntw.nearestneighbordistances(schools, destpattern=schools)
-        nndv1 = numpy.array(list(nnd1.values()))[:, 1].astype(float)
-        nndv2 = numpy.array(list(nnd2.values()))[:, 1].astype(float)
+        nndv1 = numpy.array(list(nnd1.values()), dtype=object)[:, 1].astype(float)
+        nndv2 = numpy.array(list(nnd2.values()), dtype=object)[:, 1].astype(float)
         numpy.testing.assert_array_almost_equal_nulp(nndv1, nndv2)
         del self.ntw.distance_matrix
         del self.ntw.network_trees


### PR DESCRIPTION
This PR updates `test_nearest_neighbor_distances()` to account for a `VisibleDeprecationWarning` in `numpy`.


```
spaghetti/tests/test_api_network.py::TestNetworkPointPattern::test_nearest_neighbor_distances
spaghetti/tests/test_dev_network.py::TestNetworkPointPattern::test_nearest_neighbor_distances
  /Users/user/spaghetti/spaghetti/tests/network_unittest_classes.py:638: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
    nndv1 = numpy.array(list(nnd2.values()))[:, 1].astype(float)

spaghetti/tests/test_api_network.py::TestNetworkPointPattern::test_nearest_neighbor_distances
spaghetti/tests/test_dev_network.py::TestNetworkPointPattern::test_nearest_neighbor_distances
  /Users/user/spaghetti/spaghetti/tests/network_unittest_classes.py:638: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
    nndv2 = numpy.array(list(nnd2.values()))[:, 1].astype(float)
```