### PR TITLE
bump Python version for notebooks

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: notebooks-environment
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   - descartes
   - esda
   - geopandas>=0.7.0


### PR DESCRIPTION
This PR bumps the Python version in `environment.yml`, which is used for starting binders.