### PR TITLE
update GHA workflows and drop Py3.6 Windows testing

### DIFF
--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -15,9 +15,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v2.1.4
+      uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
         TEXT: ${{ steps.changetxt.outputs.text }}
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1.1.4
+      uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # token is provided by GHA, DO NOT create
       with:
@@ -50,7 +50,7 @@ jobs:
       run: |
         export PKG=$(ls dist/)
         set -- $PKG
-        echo "::set-env name=whl_path::$1"
+        echo "whl_path=1" >> $GITHUB_ENV
     - name: Upload Release Asset
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,11 +17,11 @@
        matrix:
          os: [macos-latest, ubuntu-latest, windows-latest]
          environment-file: [ci/36-PYPI.yaml, ci/36-PYPI-PLUS.yaml, ci/36-GIT.yaml, ci/36-GIT-PLUS.yaml, ci/37-PYPI.yaml, ci/37-PYPI-PLUS.yaml, ci/37-GIT.yaml, ci/37-GIT-PLUS.yaml, ci/38-PYPI.yaml, ci/38-PYPI-PLUS.yaml, ci/38-GIT.yaml, ci/38-GIT-PLUS.yaml]
-         #exclude:
-         #  - environment-file: ci/36-PYPI-PLUS.yaml
-         #    os: windows-latest
-         #  - environment-file: ci/36-GIT-PLUS.yaml
-         #    os: windows-latest
+         exclude:
+           - environment-file: ci/36-PYPI-PLUS.yaml
+             os: windows-latest
+           - environment-file: ci/36-GIT-PLUS.yaml
+             os: windows-latest
      steps:
        - uses: actions/checkout@v2
        - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
This PR:
* ... drops testing for Python 3.6 on Windows due to the general phasing out of Python 3.6 and specifically due to `fiona` failures for Python 3.6 on Windows. See pysal/spaghetti#545.
* ... updates GHA syntax in `unittests.yml` and `release_and_publish.yml`. See [this comment](https://gitter.im/pysal/pysal?at=5fb448ecc10273610a106a51), [this blog post](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), and [this commit](https://github.com/geopandas/geopandas/commit/cdb42821ababcf29b6f7f94dd66fa9cb5a8f6071).