### PR TITLE
keep docs/notebooks directory

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,7 +24,7 @@ github:
 	@make html
 
 sync:
-	@rsync -avh --exclude '.nojekyll' _build/html/ ../docs/ --delete
+	@rsync -avh _build/html/ ../docs/ --delete
 	@make clean
 	touch ../docs/.nojekyll
 


### PR DESCRIPTION
This PR corrects a bug that was deleting `~/docs/notebooks/`.