### PR TITLE
bump 1.5.5 --> v1.5.6 after syntax error

### DIFF
--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -52,14 +52,14 @@ jobs:
         set -- $PKG
         echo "name=$1" >> $GITHUB_ENV
     - name: Upload Release Asset
-      id: upload-release-asset 
+      id: upload-release-asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: dist/${{ env.whl_path }}
-        asset_name: ${{ env.whl_path }}
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+        asset_path: dist/${{ env.name }}
+        asset_name: ${{ env.name }}
         asset_content_type: application/zip
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/spaghetti/__init__.py
+++ b/spaghetti/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.5"
+__version__ = "1.5.6"
 
 """
 # `spaghetti` --- Spatial Graphs: Networks, Topology, & Inference


### PR DESCRIPTION
This PR bumps from `v1.5.5` to `v1.5.6` after syntax error in the `release_and_publish.yml` workflow.