### PR TITLE
remove mamba & conda mixture

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -36,7 +36,6 @@
        - uses: conda-incubator/setup-miniconda@v2
          with:
             miniconda-version: 'latest'
-            mamba-version: '*'
             channels: conda-forge
             channel-priority: true
             auto-update-conda: false
@@ -44,8 +43,8 @@
             environment-file: ${{ matrix.environment-file }}
             activate-environment: test
             use-only-tar-bz2: true
-       - run: mamba info --all
-       - run: mamba list
+       - run: conda info --all
+       - run: conda list
        - run: conda config --show-sources
        - run: conda config --show
        - run: pytest -v spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml


### PR DESCRIPTION
The current `rtree` failures *may* be due to my mixing of `conda` & `mamba` in CI. Although I had [set `channel-priority: true`](https://github.com/pysal/spaghetti/blob/4638f5d197d2d91c0f24fbe35941ffcb03be94b0/.github/workflows/unittests.yml#L41), it was being implemented as [flexible in the workflow](https://github.com/pysal/spaghetti/runs/2395807363?check_suite_focus=true#step:8:27).

See [xref](https://github.com/conda-forge/rtree-feedstock/issues/31#issuecomment-824292617)

@martinfleis 