### PR TITLE
Update sphinxcontrib-bibtex

### DIFF
--- a/ci/39.yaml
+++ b/ci/39.yaml
@@ -22,6 +22,6 @@ dependencies:
   # for docs build action (this env only)
   - nbsphinx
   - numpydoc
-  - sphinx>=1.4.3
-  - sphinxcontrib-bibtex<2.0.0
+  - sphinx
+  - sphinxcontrib-bibtex
   - sphinx_bootstrap_theme

--- a/docs/_static/pysal-styles.css
+++ b/docs/_static/pysal-styles.css
@@ -76,7 +76,7 @@
       color: #E74C3C;
       font-size: 100%;
       font-weight: bold;
-      width: 125px;
+      width: 100px;
       text-align: left;
       vertical-align: middle;
 }

--- a/docs/_static/references.bib
+++ b/docs/_static/references.bib
@@ -1,123 +1,123 @@
 %% Saved with string encoding Unicode (UTF-8) 
 
 @article{Dijkstra1959a,
-    abstract = {We consider a graph with n vertices, all pairs of which are connected by an edge; each edge is of given positive length. The following two basic problems are solved. Problem 1: construct the tree of minimal total length between the n vertices. (A tree is a graph with one and only one path between any two vertices.) Problem 2: find the path of minimal total length between two given vertices.},
-    author = {Dijkstra, E. W.},
-    doi = {10.1007/BF01386390},
-    isbn = {0029-599X (Print) 0945-3245 (Online)},
-    issn = {0029-599X},
-    journal = {Numerische Mathematik},
-    number = {1},
-    pages = {269--271},
-    pmid = {18215627},
-    title = {{A Note on Two Problems in Connexion with Graphs}},
-    volume = {1},
-    year = {1959}
+  abstract = {We consider a graph with n vertices, all pairs of which are connected by an edge; each edge is of given positive length. The following two basic problems are solved. Problem 1: construct the tree of minimal total length between the n vertices. (A tree is a graph with one and only one path between any two vertices.) Problem 2: find the path of minimal total length between two given vertices.},
+  author = {Dijkstra, E. W.},
+  doi = {10.1007/BF01386390},
+  isbn = {0029-599X (Print) 0945-3245 (Online)},
+  issn = {0029-599X},
+  journal = {Numerische Mathematik},
+  number = {1},
+  pages = {269--271},
+  pmid = {18215627},
+  title = {{A Note on Two Problems in Connexion with Graphs}},
+  volume = {1},
+  year = {1959}
 }
 
 @article{Baddeley2020,
-    author = {Baddeley, Adrian and Nair, Gopalan and Rakshit, Suman and McSwiggan, Greg and Davies, Tilman M.},
-    doi = {10.1016/j.spasta.2020.100435},
-    journal = {Spatial Statistics},
-    keywords = {Distance metric,K-function,Kernel density estimation,Nonparametric estimation,Pair correlation function,Stationary process},
-    number = {xxxx},
-    pages = {100435},
-    publisher = {Elsevier B.V.},
-    title = {{Analysing point patterns on networks - A review}},
-    year = {2020}
+  author = {Baddeley, Adrian and Nair, Gopalan and Rakshit, Suman and McSwiggan, Greg and Davies, Tilman M.},
+  doi = {10.1016/j.spasta.2020.100435},
+  journal = {Spatial Statistics},
+  keywords = {Distance metric,K-function,Kernel density estimation,Nonparametric estimation,Pair correlation function,Stationary process},
+  number = {xxxx},
+  pages = {100435},
+  publisher = {Elsevier B.V.},
+  title = {{Analysing point patterns on networks - A review}},
+  year = {2020}
 }
 
 @article{doi:10.1111/j.1538-4632.2001.tb00448.x,
-    author = {Okabe, Atsuyuki and Yamada, Ikuho},
-    title = {{The K-Function Method on a Network and Its Computational Implementation}},
-    journal = {Geographical Analysis},
-    volume = {33},
-    number = {3},
-    pages = {271-290},
-    doi = {10.1111/j.1538-4632.2001.tb00448.x},
-    abstract = {This paper proposes two statistical methods, called the network K-function method and the network cross K-function method, for analyzing the distribution of points on a network. First, by extending the ordinary K-function method defined on a homogeneous infinite plane with the Euclidean distance, the paper formulates the K-function method and the cross K-function method on a finite irregular network with the shortest-path distance. Second, the paper shows advantages of the network K-function methods, such as that the network K-function methods can deal with spatial point processes on a street network in a small district, and that they can exactly take the boundary effect into account. Third, the paper develops the computational implementation of the network K-functions, and shows that the computational order of the K-function method is O(n2Q log nQ) and that of the network cross K-function is O(nQ log U3Q), where nQ is the number of nodes of a network.},
-    year = {2001}
+  author = {Okabe, Atsuyuki and Yamada, Ikuho},
+  title = {{The K-Function Method on a Network and Its Computational Implementation}},
+  journal = {Geographical Analysis},
+  volume = {33},
+  number = {3},
+  pages = {271-290},
+  doi = {10.1111/j.1538-4632.2001.tb00448.x},
+  abstract = {This paper proposes two statistical methods, called the network K-function method and the network cross K-function method, for analyzing the distribution of points on a network. First, by extending the ordinary K-function method defined on a homogeneous infinite plane with the Euclidean distance, the paper formulates the K-function method and the cross K-function method on a finite irregular network with the shortest-path distance. Second, the paper shows advantages of the network K-function methods, such as that the network K-function methods can deal with spatial point processes on a street network in a small district, and that they can exactly take the boundary effect into account. Third, the paper develops the computational implementation of the network K-functions, and shows that the computational order of the K-function method is O(n2Q log nQ) and that of the network cross K-function is O(nQ log U3Q), where nQ is the number of nodes of a network.},
+  year = {2001}
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Chapter 3 
 @inbook{doi:10.1002/9781119967101.ch3,
-    author = {Okabe, Atsuyki and Sugihara, Kokichi},
-    publisher = {John Wiley \& Sons, Ltd},
-    isbn = {9781119967101},
-    title = {Basic Computational Methods for Network Spatial Analysis},
-    booktitle = {Spatial Analysis along Networks},
-    chapter = {3},
-    pages = {45-80},
-    doi = {10.1002/9781119967101.ch3},
-    year = {2012},
-    keywords = {basic computational methods in network spatial analysis, practical computational methods, data structures for one-layer networks, winged-edge data, retrieving local information, attribute data representation, winged-edge, new nodes inserted and existing nodes deleted, nonplanar network data structure, multiple-layered networks, basic geometric computations, time complexity of algorithm, and measuring efficiency, three basic computational methods, and minimum spanning tree},
-    abstract = {Summary This chapter contains sections titled: Data structures for one-layer networks Data structures for nonplanar networks Basic geometric computations Basic computational methods on networks}
+  author = {Okabe, Atsuyki and Sugihara, Kokichi},
+  publisher = {John Wiley \& Sons, Ltd},
+  isbn = {9781119967101},
+  title = {Basic Computational Methods for Network Spatial Analysis},
+  booktitle = {Spatial Analysis along Networks},
+  chapter = {3},
+  pages = {45-80},
+  doi = {10.1002/9781119967101.ch3},
+  year = {2012},
+  keywords = {basic computational methods in network spatial analysis, practical computational methods, data structures for one-layer networks, winged-edge data, retrieving local information, attribute data representation, winged-edge, new nodes inserted and existing nodes deleted, nonplanar network data structure, multiple-layered networks, basic geometric computations, time complexity of algorithm, and measuring efficiency, three basic computational methods, and minimum spanning tree},
+  abstract = {Summary This chapter contains sections titled: Data structures for one-layer networks Data structures for nonplanar networks Basic geometric computations Basic computational methods on networks}
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Chapter 5
 @inbook{doi:10.1002/9781119967101.ch5,
-   author = {Okabe, Atsuyki and Sugihara, Kokichi},
-    publisher = {John Wiley \& Sons, Ltd},
-isbn = {9781119967101},
-title = {Network Nearest-Neighbor Distance Methods},
-booktitle = {Spatial Analysis along Networks},
-chapter = {5},
-pages = {101-118},
-doi = {10.1002/9781119967101.ch5},
-year = {2012},
-keywords = {network nearest-neighbor distance methods, neighborhood, an underlying concept common to spatial methods, network-constrained NND, neighborhood and shortest-path distance, event to next nearest event, network NND method, NND extension on plane or planar NND, network auto NND and network cross NND method, network cross NND methods, straightforward extension, local cross NND to global cross NND, network NND for lines, computational methods, for auto NND and cross NND},
-abstract = {Summary This chapter contains sections titled: Network auto nearest-neighbor distance methods Network cross nearest-neighbor distance methods Network nearest-neighbor distance method for lines Computational methods for the network nearest-neighbor distance methods}
+  author = {Okabe, Atsuyki and Sugihara, Kokichi},
+  publisher = {John Wiley \& Sons, Ltd},
+  isbn = {9781119967101},
+  title = {Network Nearest-Neighbor Distance Methods},
+  booktitle = {Spatial Analysis along Networks},
+  chapter = {5},
+  pages = {101-118},
+  doi = {10.1002/9781119967101.ch5},
+  year = {2012},
+  keywords = {network nearest-neighbor distance methods, neighborhood, an underlying concept common to spatial methods, network-constrained NND, neighborhood and shortest-path distance, event to next nearest event, network NND method, NND extension on plane or planar NND, network auto NND and network cross NND method, network cross NND methods, straightforward extension, local cross NND to global cross NND, network NND for lines, computational methods, for auto NND and cross NND},
+  abstract = {Summary This chapter contains sections titled: Network auto nearest-neighbor distance methods Network cross nearest-neighbor distance methods Network nearest-neighbor distance method for lines Computational methods for the network nearest-neighbor distance methods}
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Chapter 6
 @inbook{doi:10.1002/9781119967101.ch6,
-    author = {Okabe, Atsuyki and Sugihara, Kokichi},
-    publisher = {John Wiley \& Sons, Ltd},
-    isbn = {9781119967101},
-    title = {Network K Function Methods},
-    booktitle = {Spatial Analysis along Networks},
-    chapter = {6},
-    pages = {119-136},
-    doi = {10.1002/9781119967101.ch6},
-    year = {2012},
-    keywords = {network K function methods, distance-based methods, point pattern analysis in spatial, NND and network K function, network K function, extension of K as planar K function, K function in spatial statistics, or Ripley's K function, the planar K function, most used in spatial analysis, network K function, network auto K and the network cross K function, auto K function with one type of point, and cross K with two, global Voronoi cross K, point of type A to collection of type B points, shortest-path distance and network geometric characteristics, shortest-path distances and corresponding Euclidean distances},
-    abstract = {Summary This chapter contains sections titled: Network auto K function methods Network cross K function methods Network K function methods in relation to geometric characteristics of a network Computational methods for the network K function methods}
+  author = {Okabe, Atsuyki and Sugihara, Kokichi},
+  publisher = {John Wiley \& Sons, Ltd},
+  isbn = {9781119967101},
+  title = {Network K Function Methods},
+  booktitle = {Spatial Analysis along Networks},
+  chapter = {6},
+  pages = {119-136},
+  doi = {10.1002/9781119967101.ch6},
+  year = {2012},
+  keywords = {network K function methods, distance-based methods, point pattern analysis in spatial, NND and network K function, network K function, extension of K as planar K function, K function in spatial statistics, or Ripley's K function, the planar K function, most used in spatial analysis, network K function, network auto K and the network cross K function, auto K function with one type of point, and cross K with two, global Voronoi cross K, point of type A to collection of type B points, shortest-path distance and network geometric characteristics, shortest-path distances and corresponding Euclidean distances},
+  abstract = {Summary This chapter contains sections titled: Network auto K function methods Network cross K function methods Network K function methods in relation to geometric characteristics of a network Computational methods for the network K function methods}
 }
 
 @inbook{doi:10.1002/9780470549094.ch5,
-author = {O'Sullivan, D. and Unwin, D. J.},
-publisher = {John Wiley \& Sons, Ltd},
-isbn = {9780470549094},
-title = {Point Pattern Analysis},
-booktitle = {Geographic Information Analysis},
-chapter = {5},
-pages = {121-156},
-doi = {10.1002/9780470549094.ch5},
-year = {2010},
-keywords = {point separation, standard deviation, observed VMR, estimation methods, computationally intensive},
-abstract = {Summary This chapter contains sections titled: Introduction Describing a Point Pattern Assessing Point Patterns Statistically Monte Carlo Testing Conclusions}
+  author = {ÓSullivan, D. and Unwin, D. J.},
+  publisher = {John Wiley \& Sons, Ltd},
+  isbn = {9780470549094},
+  title = {Point Pattern Analysis},
+  booktitle = {Geographic Information Analysis},
+  chapter = {5},
+  pages = {121-156},
+  doi = {10.1002/9780470549094.ch5},
+  year = {2010},
+  keywords = {point separation, standard deviation, observed VMR, estimation methods, computationally intensive},
+  abstract = {Summary This chapter contains sections titled: Introduction Describing a Point Pattern Assessing Point Patterns Statistically Monte Carlo Testing Conclusions}
 }
 
 @article{Ripley1976,
-    author = {Ripley, Brian David},
-    doi = {10.2307/3212829},
-    journal = {Journal of Applied Probability},
-    number = {2},
-    pages = {255--266},
-    title = {{The Second-Order Analysis of Stationary Point Processes}},
-    volume = {13},
-    year = {1976}
+  author = {Ripley, Brian David},
+  doi = {10.2307/3212829},
+  journal = {Journal of Applied Probability},
+  number = {2},
+  pages = {255--266},
+  title = {{The Second-Order Analysis of Stationary Point Processes}},
+  volume = {13},
+  year = {1976}
 }
 
 @article{Ripley1977,
-    author = {Ripley, Brian David},
-    journal = {Journal of the Royal Statistical Society},
-    number = {2},
-    pages = {172--212},
-    title = {{Modelling Spatial Patterns}},
-    volume = {39},
-    year = {1977},
-    doi = {10.1111/j.2517-6161.1977.tb01615.x}
+  author = {Ripley, Brian David},
+  journal = {Journal of the Royal Statistical Society},
+  number = {2},
+  pages = {172--212},
+  title = {{Modelling Spatial Patterns}},
+  volume = {39},
+  year = {1977},
+  doi = {10.1111/j.2517-6161.1977.tb01615.x}
 }
 
 @Article{pysal2007,
@@ -133,285 +133,285 @@ abstract = {Summary This chapter contains sections titled: Introduction Describi
 }
 
 @book{AnselinRey2014,
-    address = {Chicago},
-    author = {Anselin, Luc and Rey, Sergio J.},
-    publisher = {{GeoDa Press}},
-    title = {{Modern Spatial Econometrics in Practice: A Guide to {GeoDa}, {GeoDaSpace} and {PySAL}}},
-    year = {2014}
+  address = {Chicago},
+  author = {Anselin, Luc and Rey, Sergio J.},
+  publisher = {{GeoDa Press}},
+  title = {{Modern Spatial Econometrics in Practice: A Guide to {GeoDa}, {GeoDaSpace} and {PySAL}}},
+  year = {2014}
 }
 
 @Article{rey_open_2015,
-  Title                    = {Open {Geospatial} {Analytics} with {PySAL}},
-  Author                   = {Rey, Sergio J. and Anselin, Luc and Li, Xun and Pahle, Robert and Laura, Jason and Li, Wenwen and Koschinsky, Julia},
-  Journal                  = {{ISPRS International Journal of Geo-Information}},
-  Year                     = {2015},
-  Number                   = {2},
-  Pages                    = {815--836},
-  Volume                   = {4},
-  Keywords                 = {open science},
+  Title    = {Open {Geospatial} {Analytics} with {PySAL}},
+  Author   = {Rey, Sergio J. and Anselin, Luc and Li, Xun and Pahle, Robert and Laura, Jason and Li, Wenwen and Koschinsky, Julia},
+  Journal  = {{ISPRS International Journal of Geo-Information}},
+  Year     = {2015},
+  Number   = {2},
+  Pages    = {815--836},
+  Volume   = {4},
+  Keywords = {open science},
   doi = {doi:10.3390/ijgi4020815}
 }
 
 @misc{esda:_2019,
-        author={S.J. Rey and L.J. Wolf and W. Kang and P. Stephens and J. Laura and C. Schmidt and D. Arribas-Bel and S. Lumnitz and J.C. Duque and D.C. Folch and L. Anselin and N. Malizia and J.D. Gaboardi and F. Fernandes and M. Seth and mhwang4 and mlyons-tcc},
-	title={{pysal/esda}},
-	month=jul,
-	year={2019},
-	publisher={Zenodo},
-	version={v2.1.1},
-	doi={10.5281/zenodo.3265190}
+  author={S.J. Rey and L.J. Wolf and W. Kang and P. Stephens and J. Laura and C. Schmidt and D. Arribas-Bel and S. Lumnitz and J.C. Duque and D.C. Folch and L. Anselin and N. Malizia and J.D. Gaboardi and F. Fernandes and M. Seth and mhwang4 and mlyons-tcc},
+  title={{pysal/esda}},
+  month=jul,
+  year={2019},
+  publisher={Zenodo},
+  version={v2.1.1},
+  doi={10.5281/zenodo.3265190}
 }
 
 @article{doi:10.1111/gean.12211,
-    author = {Gaboardi, James D. and Folch, David C. and Horner, Mark W.},
-    title = {{Connecting Points to Spatial Networks: Effects on Discrete Optimization Models}},
-    journal = {Geographical Analysis},
-    year = {2020},
-    volume = {52},
-    issue = {2},
-    pages = {299--322},
-    doi = {10.1111/gean.12211}, 
-    abstract = {To accommodate network allocation, population polygons are frequently transformed into singular, weighted centroids which are then integrated into the network either by snapping each centroid to the nearest network segment or by generating an artificial connector that becomes part of the network. In this article, an investigation of the connection method of network allocation is undertaken with two primary foci: (1) how the density of centroid connectors effects travel cost along the network; and (2) how the algorithms utilized to determine the placement of connectors are affected by the density of connectors. We hypothesize that both issues have an effect on network travel cost and, therefore, on network-based modeling. These hypotheses are tested on three nested spatial networks in the New England region of the United States. Two fundamental facility location models, the p-median problem, and p-center problem, are solved at each spatial extent while varying the density of connectors from one to four. When generating more than one connector thought must be given to the method of connection, the angle of dispersion, the acceptable tolerance of connector length, segment crossing, and saturated connectivity. A novel and thorough framework is proposed to address these concerns.}
+  author = {Gaboardi, James D. and Folch, David C. and Horner, Mark W.},
+  title = {{Connecting Points to Spatial Networks: Effects on Discrete Optimization Models}},
+  journal = {Geographical Analysis},
+  year = {2020},
+  volume = {52},
+  issue = {2},
+  pages = {299--322},
+  doi = {10.1111/gean.12211}, 
+  abstract = {To accommodate network allocation, population polygons are frequently transformed into singular, weighted centroids which are then integrated into the network either by snapping each centroid to the nearest network segment or by generating an artificial connector that becomes part of the network. In this article, an investigation of the connection method of network allocation is undertaken with two primary foci: (1) how the density of centroid connectors effects travel cost along the network; and (2) how the algorithms utilized to determine the placement of connectors are affected by the density of connectors. We hypothesize that both issues have an effect on network travel cost and, therefore, on network-based modeling. These hypotheses are tested on three nested spatial networks in the New England region of the United States. Two fundamental facility location models, the p-median problem, and p-center problem, are solved at each spatial extent while varying the density of connectors from one to four. When generating more than one connector thought must be given to the method of connection, the angle of dispersion, the acceptable tolerance of connector length, segment crossing, and saturated connectivity. A novel and thorough framework is proposed to address these concerns.}
 }
 
 @incollection{Cliff1981,
-address = {London},
-author = {Cliff, A.D. and Haggett, P.},
-booktitle = {Quantitative Geography: A British View},
-chapter = {22},
-editor = {Wrigley, N. and Bennett, R.J.},
-pages = {225--234},
-publisher = {Routledge {\&} Kegan Paul},
-title = {{Graph Theory}},
-year = {1981}
+  address = {London},
+  author = {Cliff, A.D. and Haggett, P.},
+  booktitle = {Quantitative Geography: A British View},
+  chapter = {22},
+  editor = {Wrigley, N. and Bennett, R.J.},
+  pages = {225--234},
+  publisher = {Routledge {\&} Kegan Paul},
+  title = {{Graph Theory}},
+  year = {1981}
 }
 
 @article{Tansel1983a,
-author = {Tansel, Barbaros C. and Francis, Richard L .and Lowe, Timothy J.},
-journal = {Management Science},
-number = {4},
-pages = {482--497},
-title = {{State of the Art---Location on Networks: A survey. Part I: The p-center and p-median Problems}},
-volume = {29},
-year = {1983},
-doi = {https://doi.org/10.1287/mnsc.29.4.482},
+  author = {Tansel, Barbaros C. and Francis, Richard L .and Lowe, Timothy J.},
+  journal = {Management Science},
+  number = {4},
+  pages = {482--497},
+  title = {{State of the Art---Location on Networks: A survey. Part I: The p-center and p-median Problems}},
+  volume = {29},
+  year = {1983},
+  doi = {https://doi.org/10.1287/mnsc.29.4.482},
 }
 
 @book{AhujaRavindraK,
-publisher = {Prentice Hall},
-isbn = {013617549X},
-year = {1993},
-title = {{Network Flows: Theory, Algorithms, and Applications}},
-language = {eng},
-address = {Englewood Cliffs, N.J.},
-author = {Ahuja, Ravindra K. and  Magnanti, Thomas L. and Orlin, James B.},
-keywords = {Network analysis (Planning); Mathematical optimization},
-lccn = {92026702},
+  publisher = {Prentice Hall},
+  isbn = {013617549X},
+  year = {1993},
+  title = {{Network Flows: Theory, Algorithms, and Applications}},
+  language = {eng},
+  address = {Englewood Cliffs, N.J.},
+  author = {Ahuja, Ravindra K. and  Magnanti, Thomas L. and Orlin, James B.},
+  keywords = {Network analysis (Planning); Mathematical optimization},
+  lccn = {92026702},
 }
 
 @incollection{Labbe1995,
-author = {Labb{\'{e}}, Martine and Peeters, Dominique and Thisse, Jacques-Fran{\c{c}}ois},
-booktitle = {Network Routing},
-chapter = {7},
-doi = {10.1016/S0927-0507(05)80111-2},
-isbn = {9780444821416},
-issn = {09270507},
-pages = {551--624},
-publisher = {Elsevier},
-series = {Handbooks in Operations Research and Management Science},
-title = {{Location on Networks}},
-volume = {8},
-year = {1995}
+  author = {Labbé, Martine and Peeters, Dominique and Thisse, Jacques-Fran{\c{c}}ois},
+  booktitle = {Network Routing},
+  chapter = {7},
+  doi = {10.1016/S0927-0507(05)80111-2},
+  isbn = {9780444821416},
+  issn = {09270507},
+  pages = {551--624},
+  publisher = {Elsevier},
+  series = {Handbooks in Operations Research and Management Science},
+  title = {{Location on Networks}},
+  volume = {8},
+  year = {1995}
 }
 
 @incollection{Kuby2009,
-title = {{Network Analysis}},
-editor = {Rob Kitchin and Nigel Thrift},
-booktitle = {{International Encyclopedia of Human Geography}},
-publisher = {Elsevier},
-address = {Oxford},
-pages = {391--398},
-year = {2009},
-isbn = {978-0-08-044910-4},
-doi = {https://doi.org/10.1016/B978-008044910-4.00481-8},
-author = {Kuby, M.J. and Roberts, T.D. and Upchurch, C.D. and S. Tierney}
+  title = {{Network Analysis}},
+  editor = {Rob Kitchin and Nigel Thrift},
+  booktitle = {{International Encyclopedia of Human Geography}},
+  publisher = {Elsevier},
+  address = {Oxford},
+  pages = {391--398},
+  year = {2009},
+  isbn = {978-0-08-044910-4},
+  doi = {https://doi.org/10.1016/B978-008044910-4.00481-8},
+  author = {Kuby, M.J. and Roberts, T.D. and Upchurch, C.D. and S. Tierney}
 }
 
 @article{Barthelemy2011,
-author = {Barth{\'{e}}lemy, Marc},
-isbn = {0370-1573},
-issn = {03701573},
-journal = {Physics Reports},
-number = {1--3},
-pages = {1--101},
-pmid = {24906003},
-publisher = {Elsevier B.V.},
-title = {{Spatial networks}},
-volume = {499},
-year = {2011},
-doi = {https://doi.org/10.1016/j.physrep.2010.11.002},
+  author = {Barthélemy, Marc},
+  isbn = {0370-1573},
+  issn = {03701573},
+  journal = {Physics Reports},
+  number = {1--3},
+  pages = {1--101},
+  pmid = {24906003},
+  publisher = {Elsevier B.V.},
+  title = {{Spatial networks}},
+  volume = {499},
+  year = {2011},
+  doi = {https://doi.org/10.1016/j.physrep.2010.11.002},
 }
 
 @book{Okabe2012,
-address = {West Sussex, UK},
-author = {Okabe, Atsuyki and Sugihara, Kokichi},
-publisher = {John Wiley {\&} Sons, Inc.},
-title = {{Spatial Analysis Along Networks}},
-year = {2012},
-doi = {10.1002/9781119967101}
+  address = {West Sussex, UK},
+  author = {Okabe, Atsuyki and Sugihara, Kokichi},
+  publisher = {John Wiley {\&} Sons, Inc.},
+  title = {{Spatial Analysis Along Networks}},
+  year = {2012},
+  doi = {10.1002/9781119967101}
 }
 
 @book{daskin2013,
-author = {Mark S. Daskin},
-publisher = {John Wiley \& Sons, Ltd},
-isbn = {9781118537015},
-title = {{Network and Discrete Location: Models, Algorithms, and Applications, Second Edition}},
-doi = {10.1002/9781118537015},
-year = {2013},
-keywords = {location taxonomy, analytic models, continuous models, discrete location models, network models, maximum covering model, ambulance location, landfill location},
+  author = {Mark S. Daskin},
+  publisher = {John Wiley \& Sons, Ltd},
+  isbn = {9781118537015},
+  title = {{Network and Discrete Location: Models, Algorithms, and Applications, Second Edition}},
+  doi = {10.1002/9781118537015},
+  year = {2013},
+  keywords = {location taxonomy, analytic models, continuous models, discrete location models, network models, maximum covering model, ambulance location, landfill location},
 }
 
 @article{Ducruet2014,
-author = {Ducruet, C{\'{e}}sar and Beauguitte, Laurent},
-doi = {10.1007/s11067-013-9222-6},
-issn = {15729427},
-journal = {Networks and Spatial Economics},
-number = {3--4},
-pages = {297--316},
-title = {{Spatial Science and Network Science: Review and Outcomes of a Complex Relationship}},
-volume = {14},
-year = {2014}
+  author = {Ducruet, César and Beauguitte, Laurent},
+  doi = {10.1007/s11067-013-9222-6},
+  issn = {15729427},
+  journal = {Networks and Spatial Economics},
+  number = {3--4},
+  pages = {297--316},
+  title = {{Spatial Science and Network Science: Review and Outcomes of a Complex Relationship}},
+  volume = {14},
+  year = {2014}
 }
 
 @article{Weber2016,
-author = {Weber, Joe},
-doi = {10.1080/00330124.2015.1106324},
-issn = {0033-0124},
-journal = {The Professional Geographer},
-number = {January},
-pages = {1--11},
-title = {{The Properties of Topological Network Connectivity Measures and Their Application to U.S. Urban Freeway Networks}},
-volume = {0124},
-year = {2016}
+  author = {Weber, Joe},
+  doi = {10.1080/00330124.2015.1106324},
+  issn = {0033-0124},
+  journal = {The Professional Geographer},
+  number = {January},
+  pages = {1--11},
+  title = {{The Properties of Topological Network Connectivity Measures and Their Application to U.S. Urban Freeway Networks}},
+  volume = {0124},
+  year = {2016}
 }
 
 @article{Okabe2006a,
-author = {Okabe, Atsuyuki and Okunuki, Keiichi and Shiode, Shino},
-doi = {10.1111/j.0016-7363.2005.00674.x},
-isbn = {1538-4632},
-issn = {0016-7363},
-journal = {Geographical Analysis},
-pages = {57--66},
-title = {{SANET: A Toolbox for Spatial Analysis on a Network}},
-volume = {38},
-year = {2006}
+  author = {Okabe, Atsuyuki and Okunuki, Keiichi and Shiode, Shino},
+  doi = {10.1111/j.0016-7363.2005.00674.x},
+  isbn = {1538-4632},
+  issn = {0016-7363},
+  journal = {Geographical Analysis},
+  pages = {57--66},
+  title = {{SANET: A Toolbox for Spatial Analysis on a Network}},
+  volume = {38},
+  year = {2006}
 }
 
 @inproceedings{Hagberg2008,
-address = {Pasadena, CA USA},
-author = {Hagberg, A.A. and Schult, D.A. and Swart, P.J.},
-booktitle = {Proceedings of the 7th Python in Science Conference (SciPy 2008)},
-editor = {Varoquaux, G. and Vaught, T. and Millman, J.},
-isbn = {3333333333},
-issn = {1540-9295},
-pages = {11--15},
-title = {{Exploring Network Structure, Dynamics, and Function using NetworkX}},
-year = {2008}
+  address = {Pasadena, CA USA},
+  author = {Hagberg, A.A. and Schult, D.A. and Swart, P.J.},
+  booktitle = {Proceedings of the 7th Python in Science Conference (SciPy 2008)},
+  editor = {Varoquaux, G. and Vaught, T. and Millman, J.},
+  isbn = {3333333333},
+  issn = {1540-9295},
+  pages = {11--15},
+  title = {{Exploring Network Structure, Dynamics, and Function using NetworkX}},
+  year = {2008}
 }
 
 @article{Foti2012,
-author = {Foti, Fletcher and Waddell, Paul and Luxen, Dennis},
-journal = {{4th Transportation Research Board Conference on Innovations in Travel Modeling (ITM)}},
-pages = {1--14},
-title = {{A Generalized Computational Framework for Accessibility: From the Pedestrian to the Metropolitan Scale}},
-year = {2012}
+  author = {Foti, Fletcher and Waddell, Paul and Luxen, Dennis},
+  journal = {{4th Transportation Research Board Conference on Innovations in Travel Modeling (ITM)}},
+  pages = {1--14},
+  title = {{A Generalized Computational Framework for Accessibility: From the Pedestrian to the Metropolitan Scale}},
+  year = {2012}
 }
 
 @article{Boeing2017,
-author = {Boeing, Geoff},
-doi = {10.1016/j.compenvurbsys.2017.05.004},
-issn = {01989715},
-journal = {Computers, Environment and Urban Systems},
-pages = {126--139},
-publisher = {Elsevier Ltd},
-title = {{OSMnx: New Methods for Acquiring, Constructing, Analyzing, and Visualizing Complex Street Networks}},
-volume = {65},
-year = {2017}
+  author = {Boeing, Geoff},
+  doi = {10.1016/j.compenvurbsys.2017.05.004},
+  issn = {01989715},
+  journal = {Computers, Environment and Urban Systems},
+  pages = {126--139},
+  publisher = {Elsevier Ltd},
+  title = {{OSMnx: New Methods for Acquiring, Constructing, Analyzing, and Visualizing Complex Street Networks}},
+  volume = {65},
+  year = {2017}
 }
 
 @article{Hakimi1964,
-author = {Hakimi, S. L.},
-doi = {10.1287/opre.12.3.450},
-isbn = {0030364X},
-issn = {0030-364X},
-journal = {Operations Research},
-number = {3},
-pages = {450--459},
-pmid = {8598587},
-title = {{Optimum Locations of Switching Centers and the Absolute Centers and Medians of a Graph}},
-volume = {12},
-year = {1964}
+  author = {Hakimi, S. L.},
+  doi = {10.1287/opre.12.3.450},
+  isbn = {0030364X},
+  issn = {0030-364X},
+  journal = {Operations Research},
+  number = {3},
+  pages = {450--459},
+  pmid = {8598587},
+  title = {{Optimum Locations of Switching Centers and the Absolute Centers and Medians of a Graph}},
+  volume = {12},
+  year = {1964}
 }
 
 @article{ReVelle1970,
-author = {ReVelle, C. S. and Swain, R.W.},
-journal = {Geographical Analysis},
-number = {1},
-pages = {30--42},
-title = {{Central Facilities Location}},
-volume = {2},
-year = {1970}
+  author = {ReVelle, C. S. and Swain, R.W.},
+  journal = {Geographical Analysis},
+  number = {1},
+  pages = {30--42},
+  title = {{Central Facilities Location}},
+  volume = {2},
+  year = {1970}
 }
 
 @article{Toregas1971,
-author = {Toregas, Constantine and Swain, R. and ReVelle, C. S. and Bergman, L.},
-doi = {10.1287/opre.19.6.1363},
-isbn = {0030364X},
-issn = {0030-364X},
-journal = {Operations Research},
-number = {6},
-pages = {1363--1373},
-title = {{The Location of Emergency Service Facilities}},
-volume = {19},
-year = {1971}
+  author = {Toregas, Constantine and Swain, R. and ReVelle, C. S. and Bergman, L.},
+  doi = {10.1287/opre.19.6.1363},
+  isbn = {0030364X},
+  issn = {0030-364X},
+  journal = {Operations Research},
+  number = {6},
+  pages = {1363--1373},
+  title = {{The Location of Emergency Service Facilities}},
+  volume = {19},
+  year = {1971}
 }
 
 @article{Toregas1972,
-author = {Toregas, Constantine and ReVelle, Charles S.},
-doi = {10.1017/CBO9781107415324.004},
-isbn = {9788578110796},
-issn = {1098-6596},
-journal = {Papers of the Regional Science Association},
-number = {1},
-pages = {133 -- 144},
-pmid = {25246403},
-title = {{Optimal Location Under Time or Distance Constraints}},
-volume = {28},
-year = {1972}
+  author = {Toregas, Constantine and ReVelle, Charles S.},
+  doi = {10.1017/CBO9781107415324.004},
+  isbn = {9788578110796},
+  issn = {1098-6596},
+  journal = {Papers of the Regional Science Association},
+  number = {1},
+  pages = {133 -- 144},
+  pmid = {25246403},
+  title = {{Optimal Location Under Time or Distance Constraints}},
+  volume = {28},
+  year = {1972}
 }
 
 @article{Church1974,
-author = {Church, Richard L. and ReVelle, C.S.},
-doi = {doi.org/10.1111/j.1435-5597.1974.tb00902.x},
-isbn = {10568190 (ISSN)},
-issn = {10568190},
-journal = {Papers in Regional Science Association},
-pages = {101--118},
-title = {{The Maximal Covering Location Problem}},
-volume = {32},
-year = {1974}
+  author = {Church, Richard L. and ReVelle, C.S.},
+  doi = {doi.org/10.1111/j.1435-5597.1974.tb00902.x},
+  isbn = {10568190 (ISSN)},
+  issn = {10568190},
+  journal = {Papers in Regional Science Association},
+  pages = {101--118},
+  title = {{The Maximal Covering Location Problem}},
+  volume = {32},
+  year = {1974}
 }
 
 @article{ReVelle2005,
-author = {ReVelle, C. S. and Eiselt, H. A.},
-doi = {10.1016/j.ejor.2003.11.032},
-isbn = {1410516709},
-issn = {01679295},
-journal = {European Journal of Operational Research},
-pages = {1--19},
-title = {{Location analysis: A synthesis and survey}},
-volume = {165},
-year = {2005}
+  author = {ReVelle, C. S. and Eiselt, H. A.},
+  doi = {10.1016/j.ejor.2003.11.032},
+  isbn = {1410516709},
+  issn = {01679295},
+  journal = {European Journal of Operational Research},
+  pages = {1--19},
+  title = {{Location analysis: A synthesis and survey}},
+  volume = {165},
+  year = {2005}
 }
 
 @misc{tom_russell_2019_3379659,
@@ -426,184 +426,192 @@ year = {2005}
  
  
  @article{Bektas2014,
-author = {Bektaş, Tolga and Gouveia, Luis},
-doi = {10.1016/j.ejor.2013.07.038},
-issn = {03772217},
-journal = {European Journal of Operational Research},
-number = {3},
-pages = {820--832},
-title = {{Requiem for the Miller-Tucker-Zemlin subtour elimination constraints?}},
-volume = {236},
-year = {2014}
+  author = {Bektaş, Tolga and Gouveia, Luis},
+  doi = {10.1016/j.ejor.2013.07.038},
+  issn = {03772217},
+  journal = {European Journal of Operational Research},
+  number = {3},
+  pages = {820--832},
+  title = {{Requiem for the Miller-Tucker-Zemlin subtour elimination constraints?}},
+  volume = {236},
+  year = {2014}
 }
 @article{Miller1960,
-author = {Miller, C. E. and Tucker, A. W. and Zemlin, R. A.},
-doi = {10.1145/321043.321046},
-issn = {1557735X},
-journal = {Journal of the ACM (JACM)},
-number = {4},
-pages = {326--329},
-title = {{Integer Programming Formulation of Traveling Salesman Problems}},
-volume = {7},
-year = {1960}
+  author = {Miller, C. E. and Tucker, A. W. and Zemlin, R. A.},
+  doi = {10.1145/321043.321046},
+  issn = {1557735X},
+  journal = {Journal of the ACM (JACM)},
+  number = {4},
+  pages = {326--329},
+  title = {{Integer Programming Formulation of Traveling Salesman Problems}},
+  volume = {7},
+  year = {1960}
 }
+
 @article{Flood1956,
-author = {Flood, Merrill M.},
-journal = {Operations Research},
-number = {1},
-pages = {61--75},
-title = {{The Traveling-Salesman Problem}},
-volume = {4},
-year = {1956}
+  author = {Flood, Merrill M.},
+  journal = {Operations Research},
+  number = {1},
+  pages = {61--75},
+  title = {{The Traveling-Salesman Problem}},
+  volume = {4},
+  year = {1956}
 }
+
 @article{Dantzig1954,
-author = {Dantzig, G. and Fulkerson, R. and Johnson, S.},
-journal = {Journal of the Operational Research Society of America},
-number = {4},
-pages = {393--410},
-title = {{Solution of a Large-Scale Traveling-Salesman Problem}},
-volume = {2},
-year = {1954}
+  author = {Dantzig, G. and Fulkerson, R. and Johnson, S.},
+  journal = {Journal of the Operational Research Society of America},
+  number = {4},
+  pages = {393--410},
+  title = {{Solution of a Large-Scale Traveling-Salesman Problem}},
+  volume = {2},
+  year = {1954}
 }
 
 @book{Miller2001,
-address = {New York},
-author = {Miller, Harvey J. and Shaw, Shih-Lung},
-publisher = {Oxford University Press},
-title = {{Geographic Information Systems for Transportation}},
-year = {2001}
+  address = {New York},
+  author = {Miller, Harvey J. and Shaw, Shih-Lung},
+  publisher = {Oxford University Press},
+  title = {{Geographic Information Systems for Transportation}},
+  year = {2001}
 }
+
 @book{Gass2005,
-address = {New York},
-author = {Gass, Saul I. and Assad, Arjang A.},
-publisher = {Springer},
-title = {{An Annotated Timeline of Operations Research: An Informal History}},
-year = {2005}
+  address = {New York},
+  author = {Gass, Saul I. and Assad, Arjang A.},
+  publisher = {Springer},
+  title = {{An Annotated Timeline of Operations Research: An Informal History}},
+  year = {2005}
 }
+
 @misc{Cummings2000,
-   author = {Cummings, Nigel},
-   title = {A brief History of the Travelling Salesman Problem},
-   editor = {The Operational Research Society},
-   month =  {jun},
-   year =  {2000},
-   url = {https://www.theorsociety.com/about-or/or-methods/heuristics/a-brief-history-of-the-travelling-salesman-problem/},
-   note =  {Accessed: January, 2020},
- }
+  author = {Cummings, Nigel},
+  title = {A brief History of the Travelling Salesman Problem},
+  editor = {The Operational Research Society},
+  month =  {jun},
+  year =  {2000},
+  url = {https://www.theorsociety.com/about-or/or-methods/heuristics/a-brief-history-of-the-travelling-salesman-problem/},
+  note =  {Accessed: January, 2020},
+}
+
 @book{Church2009,
-address = {Hoboken},
-author = {Church, Richard L. and Murray, Alan T.},
-publisher = {John Wiley {\&} Sons, Inc.},
-title = {{Business Site Selection, Locational Analysis, and GIS}},
-year = {2009}
+  address = {Hoboken},
+  author = {Church, Richard L. and Murray, Alan T.},
+  publisher = {John Wiley {\&} Sons, Inc.},
+  title = {{Business Site Selection, Locational Analysis, and GIS}},
+  year = {2009}
 }
+
 @article{Koopmans1949,
-author = {Koopmans, Tjalling},
-journal = {Econometrica},
-pages = {136--146},
-title = {{Optimum Utilization of the Transportation System}},
-volume = {17},
-year = {1949}
+  author = {Koopmans, Tjalling},
+  journal = {Econometrica},
+  pages = {136--146},
+  title = {{Optimum Utilization of the Transportation System}},
+  volume = {17},
+  year = {1949}
 }
+
 @book{Phillips1981a,
-address = {Englewood Cliffs, NJ},
-author = {Phillips, Don T. and Garcia-Diaz, Alberto},
-publisher = {Prentice Hall},
-title = {{Fundamentals of Network Analysis}},
-year = {1981}
+  address = {Englewood Cliffs, NJ},
+  author = {Phillips, Don T. and Garcia-Diaz, Alberto},
+  publisher = {Prentice Hall},
+  title = {{Fundamentals of Network Analysis}},
+  year = {1981}
 }
+
 @article{Hitchcock1941,
-    author = {Hitchcock, Frank L.},
-    doi = {10.1017/CBO9781107415324.004},
-    isbn = {9788578110796},
-    issn = {1098-6596},
-    journal = {Journal of Math and Physics},
-    number = {1},
-    pages = {224--230},
-    pmid = {25246403},
-    title = {{The Distribution of a Product from Several Sources to Numerous Localities}},
-    volume = {20},
-    year = {1941}
+  author = {Hitchcock, Frank L.},
+  doi = {10.1017/CBO9781107415324.004},
+  isbn = {9788578110796},
+  issn = {1098-6596},
+  journal = {Journal of Math and Physics},
+  number = {1},
+  pages = {224--230},
+  pmid = {25246403},
+  title = {{The Distribution of a Product from Several Sources to Numerous Localities}},
+  volume = {20},
+  year = {1941}
 }
 
 @article{GrahamHell_1985,
-        author = {Graham, R. L. and Hell, Pavol},
-        title = {On the History of the Minimum Spanning Tree Problem},
-        year = {1985},
-        volume = {7},
-        number = {1},
-        doi = {10.1109/MAHC.1985.10011},
-        journal = {IEEE Annals of the History of Computing},
-        pages = {43-57}
+  author = {Graham, R. L. and Hell, Pavol},
+  title = {On the History of the Minimum Spanning Tree Problem},
+  year = {1985},
+  volume = {7},
+  number = {1},
+  doi = {10.1109/MAHC.1985.10011},
+  journal = {IEEE Annals of the History of Computing},
+  pages = {43-57}
 }
 
 @article{Moran1950,
-        author = {Moran, P. A. P.},
-        doi = {10.2307/2332142},
-        journal = {Biometrika},
-        number = {1/2},
-        pages = {17-23},
-        title = {{Notes on Continuous Stochastic Phenomena}},
-        volume = {37},
-        year = {1950}
+  author = {Moran, P. A. P.},
+  doi = {10.2307/2332142},
+  journal = {Biometrika},
+  number = {1/2},
+  pages = {17-23},
+  title = {{Notes on Continuous Stochastic Phenomena}},
+  volume = {37},
+  year = {1950}
 }
 
 @article{Getis1992,
-        author = {Getis, Arthur and Ord, J. K.},
-        doi = {10.1111/j.1538-4632.1992.tb00261.x},
-        journal = {Geographical Analysis},
-        number = {3},
-        pages = {189--206},
-        title = {{The Analysis of Spatial Association by Use of Distance Statistics}},
-        volume = {24},
-        year = {1992}
+  author = {Getis, Arthur and Ord, J. K.},
+  doi = {10.1111/j.1538-4632.1992.tb00261.x},
+  journal = {Geographical Analysis},
+  number = {3},
+  pages = {189--206},
+  title = {{The Analysis of Spatial Association by Use of Distance Statistics}},
+  volume = {24},
+  year = {1992}
 }
 
 @article{Lumnitz2020,
-        author = {Lumnitz, Stefanie and Arribas-Bell, Dani and Cortes, Renan X. and Gaboardi, James D. and Griess, Verena and Kang, Wei and Oshan, Taylor M. and Wolf, Levi and Rey, Sergio},
-        doi = {10.21105/joss.01882},
-        journal = {Journal of Open Source Software},
-        number = {47},
-        pages = {1--4},
-        title = {splot - visual analytics for spatial statistics},
-        volume = {5},
-        year = {2020}
+  author = {Lumnitz, Stefanie and Arribas-Bell, Dani and Cortes, Renan X. and Gaboardi, James D. and Griess, Verena and Kang, Wei and Oshan, Taylor M. and Wolf, Levi and Rey, Sergio},
+  doi = {10.21105/joss.01882},
+  journal = {Journal of Open Source Software},
+  number = {47},
+  pages = {1--4},
+  title = {splot - visual analytics for spatial statistics},
+  volume = {5},
+  year = {2020}
 }
 
 @misc{splot:package:_2020,
-          author       = {Stefanie Lumnitz and
-                          Dani Arribas-Bel and
-                          Renan Xavier Cortes and
-                          James Gaboardi and
-                          Verena Griess and
-                          Wei Kang and
-                          Taylor Oshan and
-                          Levi John Wolf and
-                          Sergio Rey},
-          title        = {splot - visual analytics for spatial statistics},
-          month        = mar,
-          year         = 2020,
-          publisher    = {Zenodo},
-          version      = {v.1.1.3},
-          doi          = {10.5281/zenodo.3724199},
+  author    = {Stefanie Lumnitz and
+               Dani Arribas-Bel and
+               Renan Xavier Cortes and
+               James Gaboardi and
+               Verena Griess and
+               Wei Kang and
+               Taylor Oshan and
+               Levi John Wolf and
+               Sergio Rey},
+  title     = {splot - visual analytics for spatial statistics},
+  month     = mar,
+  year      = 2020,
+  publisher = {Zenodo},
+  version   = {v.1.1.3},
+  doi       = {10.5281/zenodo.3724199},
 }
 
 @article{Anselin1995,
-    author = {Anselin, Luc},
-    doi = {10.1111/j.1538-4632.1995.tb00338.x},
-    journal = {Geographical Analysis},
-    number = {2},
-    pages = {93--115},
-    title = {{Local indicators of spatial association --- LISA}},
-    volume = {27},
-    year = {1995}
+  author = {Anselin, Luc},
+  doi = {10.1111/j.1538-4632.1995.tb00338.x},
+  journal = {Geographical Analysis},
+  number = {2},
+  pages = {93--115},
+  title = {{Local indicators of spatial association --- LISA}},
+  volume = {27},
+  year = {1995}
 }
 
 @book{moran:_cliff81,
-	Address = {London},
-	Author = {Cliff, A.D. and Ord, J.K.},
-	Publisher = {Pion},
-	Title = {Spatial Processes: Models and Applications},
-	Year = {1981}
+  Address = {London},
+  Author = {Cliff, A.D. and Ord, J.K.},
+  Publisher = {Pion},
+  Title = {Spatial Processes: Models and Applications},
+  Year = {1981}
 }
 
 @article{Gaboardi2021,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,12 +11,9 @@
 import sys, os
 import sphinx_bootstrap_theme
 
-
-sys.path.insert(0, os.path.abspath("../"))
-
 # import your package to obtain the version info to display on the docs website
+sys.path.insert(0, os.path.abspath("../"))
 import spaghetti
-
 
 # -- General configuration ------------------------------------------------
 
@@ -37,7 +34,7 @@ extensions = [  #'sphinx_gallery.gen_gallery',
     "numpydoc",
     "nbsphinx",
 ]
-
+bibtex_bibfiles = ["_static/references.bib"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
This PR updates `sphinxcontrib-bibtex` to resolve the ongoing issue that required pinning version `<2.0.0`.

* See original issue [here](https://github.com/executablebooks/jupyter-book/issues/1137#issuecomment-743994864).