### PR TITLE
add deprecation warning for libpysal geometries

### DIFF
--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -23,9 +23,17 @@ __all__ = ["Network", "PointPattern", "GlobalAutoK"]
 SAME_SEGMENT = (-0.1, -0.1)
 
 
-dep_msg = "The next major release of pysal/spaghetti (2.0.0) will drop support for all ``libpysal.cg`` geometries."
-warnings.simplefilter("always", DeprecationWarning)
-warnings.warn(f"{dep_msg}", DeprecationWarning)
+dep_msg = "The next major release of pysal/spaghetti (2.0.0) will "
+dep_msg += "drop support for all ``libpysal.cg`` geometries, which "
+dep_msg += "includes using ``libpysal.cg`` geometries for network "
+dep_msg += "instantiation and all internal computation. This change "
+dep_msg += "is a first step in refactoring ``spaghetti`` that is "
+dep_msg += "expected to result in dramatically reduced runtimes for "
+dep_msg += "network instantiation and operations. Users currently "
+dep_msg += "requiring network and point pattern input as ``libpysal.cg`` "
+dep_msg += "geometries should prepare for this simply by converting "
+dep_msg += "to ``shapely`` geometries."
+warnings.warn(f"{dep_msg}", FutureWarning)
 
 
 class Network:

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -23,16 +23,16 @@ __all__ = ["Network", "PointPattern", "GlobalAutoK"]
 SAME_SEGMENT = (-0.1, -0.1)
 
 
-dep_msg = "The next major release of pysal/spaghetti (2.0.0) will "
-dep_msg += "drop support for all ``libpysal.cg`` geometries, which "
-dep_msg += "includes using ``libpysal.cg`` geometries for network "
-dep_msg += "instantiation and all internal computation. This change "
-dep_msg += "is a first step in refactoring ``spaghetti`` that is "
-dep_msg += "expected to result in dramatically reduced runtimes for "
-dep_msg += "network instantiation and operations. Users currently "
-dep_msg += "requiring network and point pattern input as ``libpysal.cg`` "
-dep_msg += "geometries should prepare for this simply by converting "
-dep_msg += "to ``shapely`` geometries."
+dep_msg = (
+    "The next major release of pysal/spaghetti (2.0.0) will "
+    "drop support for all ``libpysal.cg`` geometries. This change "
+    "is a first step in refactoring ``spaghetti`` that is "
+    "expected to result in dramatically reduced runtimes for "
+    "network instantiation and operations. Users currently "
+    "requiring network and point pattern input as ``libpysal.cg`` "
+    "geometries should prepare for this simply by converting "
+    "to ``shapely`` geometries."
+    )
 warnings.warn(f"{dep_msg}", FutureWarning)
 
 

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -23,6 +23,11 @@ __all__ = ["Network", "PointPattern", "GlobalAutoK"]
 SAME_SEGMENT = (-0.1, -0.1)
 
 
+dep_msg = "The next major release of pysal/spaghetti (2.0.0) will drop support for all ``libpysal.cg`` geometries."
+warnings.simplefilter("always", DeprecationWarning)
+warnings.warn(f"{dep_msg}", DeprecationWarning)
+
+
 class Network:
     """Spatially-constrained network representation and analytical
     functionality. Naming conventions are as follows, (1) arcs and


### PR DESCRIPTION
This PR kicks of the process of deprecating `libpysal` geometries and overhauling `spaghetti`.

xref: pysal/spaghetti#646 ([comment](https://github.com/pysal/spaghetti/issues/646#issuecomment-917734798)), [Refactor spaghetti](https://github.com/pysal/spaghetti/wiki/Refactor:-spaghetti-v2.0#2021-08-09-thoughts-james)