### PR TITLE
Pytest-xdist for multicore tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,11 +20,7 @@
    unittests:
      env:
        PIP_INSTALL: pip install git+https://github.com/pysal/
-       RUN_TEST: >
-         pytest -v -n auto spaghetti
-         --cov spaghetti --doctest-modules
-         --cov-config .coveragerc --cov-report xml 
-         --color yes --cov-append --cov-report term-missing
+       RUN_TEST: pytest -v -n auto spaghetti --cov spaghetti --doctest-modules --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
      name: ${{ matrix.os }}, ${{ matrix.env-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,7 @@
  jobs:
    unittests:
      env:
-       RUN_TEST: pytest -v -n 4 spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
+       RUN_TEST: pytest -v -n auto spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
      name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -25,13 +25,13 @@
          --cov spaghetti --doctest-modules \
          --cov-config .coveragerc --cov-report xml \
          --color yes --cov-append --cov-report term-missing
-     name: ${{ matrix.os }}, ${{ matrix.environment-file }}
+     name: ${{ matrix.os }}, ${{ matrix.env-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30
      strategy:
        matrix:
          os: [ubuntu-latest]
-         environment-file:
+         env-file:
            - ci/37.yaml
            - ci/38.yaml
            - ci/39.yaml
@@ -39,9 +39,9 @@
            - ci/310-BASE.yaml
            - ci/310-DEV.yaml
          include:
-           - environment-file: ci/310.yaml
+           - env-file: ci/310.yaml
              os: macos-latest
-           - environment-file: ci/310.yaml
+           - env-file: ci/310.yaml
              os: windows-latest
      
      steps:
@@ -51,7 +51,7 @@
        - name: setup micromamba
          uses: mamba-org/provision-with-micromamba@main
          with:
-           environment-file: ${{ matrix.environment-file }}
+           env-file: ${{ matrix.env-file }}
            micromamba-version: 'latest'
       
        - name: install bleeding edge libpysal & esda (Ubuntu / Python 3.10)
@@ -59,9 +59,7 @@
          run: |
            ${{ env.PIP_INSTALL }}libpysal.git@master
            ${{ env.PIP_INSTALL }}esda.git@master
-         if: |
-           matrix.os == 'ubuntu-latest'
-           && contains(matrix.environment-file, 'DEV')
+         if: matrix.os == 'ubuntu-latest' && contains(matrix.env-file, 'DEV')
        
        - name: run tests - bash
          shell: bash -l {0}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,10 +20,10 @@
    unittests:
      env:
        PIP_INSTALL: pip install git+https://github.com/pysal/
-       RUN_TEST: |
-         pytest -v -n auto spaghetti \
-         --cov spaghetti --doctest-modules \
-         --cov-config .coveragerc --cov-report xml \
+       RUN_TEST: >
+         pytest -v -n auto spaghetti
+         --cov spaghetti --doctest-modules
+         --cov-config .coveragerc --cov-report xml 
          --color yes --cov-append --cov-report term-missing
      name: ${{ matrix.os }}, ${{ matrix.env-file }}
      runs-on: ${{ matrix.os }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,12 +19,12 @@
  jobs:
    unittests:
      env:
+       PIP_INSTALL: pip install git+https://github.com/pysal/
        RUN_TEST: |
          pytest -v -n auto spaghetti \
          --cov spaghetti --doctest-modules \
          --cov-config .coveragerc --cov-report xml \
          --color yes --cov-append --cov-report term-missing
-       PIP_INSTALL: pip install git+https://github.com/pysal/
      name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30
@@ -54,12 +54,14 @@
            environment-file: ${{ matrix.environment-file }}
            micromamba-version: 'latest'
       
-       - name: install bleeding edge libpysal & esda (only Ubuntu / Python 3.10)
+       - name: install bleeding edge libpysal & esda (Ubuntu / Python 3.10)
          shell: bash -l {0}
          run: |
            ${{ env.PIP_INSTALL }}libpysal.git@master
            ${{ env.PIP_INSTALL }}esda.git@master
-         if: matrix.os == 'ubuntu-latest' && contains(matrix.environment-file, 'DEV')
+         if: |
+           matrix.os == 'ubuntu-latest' \
+           && contains(matrix.environment-file, 'DEV')
        
        - name: run tests - bash
          shell: bash -l {0}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,7 +20,6 @@
    unittests:
      env:
        PIP_INSTALL: pip install git+https://github.com/pysal/
-       BRANCH: .git@master
        RUN_TEST: |
          pytest -v -n auto spaghetti \
          --cov spaghetti --doctest-modules \
@@ -58,8 +57,8 @@
        - name: install bleeding edge libpysal & esda (Ubuntu / Python 3.10)
          shell: bash -l {0}
          run: |
-           ${{ env.PIP_INSTALL }}libpysal${{ env.BRANCH }}
-           ${{ env.PIP_INSTALL }}esda${{ env.BRANCH }}
+           ${{ env.PIP_INSTALL }}libpysal.git@master
+           ${{ env.PIP_INSTALL }}esda.git@master
          if: matrix.os == 'ubuntu-latest' && contains(matrix.env, 'DEV')
        
        - name: run tests - bash

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -52,12 +52,12 @@
        
        - name: run tests - bash
          shell: bash -l {0}
-         run: env.RUN_TEST
+         run: ${{ env.RUN_TEST }}
          if: matrix.os != 'windows-latest'
        
        - name: run tests - powershell
          shell: powershell
-         run: env.RUN_TEST
+         run: ${{ env.RUN_TEST }}
          if: matrix.os == 'windows-latest'
        
        - name: codecov

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,7 @@
  jobs:
    unittests:
      env:
-       RUN_TEST: pytest -v -n auto spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report xml --color=yes --cov-append --cov-report term-missing
+       RUN_TEST: pytest -v -n auto spaghetti --cov spaghetti --doctest-modules --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
      name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -25,13 +25,13 @@
          --cov spaghetti --doctest-modules \
          --cov-config .coveragerc --cov-report xml \
          --color yes --cov-append --cov-report term-missing
-     name: ${{ matrix.os }}, ${{ matrix.env }}
+     name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30
      strategy:
        matrix:
          os: [ubuntu-latest]
-         env:
+         environment-file:
            - ci/37.yaml
            - ci/38.yaml
            - ci/39.yaml
@@ -39,9 +39,9 @@
            - ci/310-BASE.yaml
            - ci/310-DEV.yaml
          include:
-           - env: ci/310.yaml
+           - environment-file: ci/310.yaml
              os: macos-latest
-           - env: ci/310.yaml
+           - environment-file: ci/310.yaml
              os: windows-latest
      
      steps:
@@ -51,7 +51,7 @@
        - name: setup micromamba
          uses: mamba-org/provision-with-micromamba@main
          with:
-           env: ${{ matrix.env }}
+           environment-file: ${{ matrix.environment-file }}
            micromamba-version: 'latest'
       
        - name: install bleeding edge libpysal & esda (Ubuntu / Python 3.10)
@@ -59,7 +59,9 @@
          run: |
            ${{ env.PIP_INSTALL }}libpysal.git@master
            ${{ env.PIP_INSTALL }}esda.git@master
-         if: matrix.os == 'ubuntu-latest' && contains(matrix.env, 'DEV')
+         if: |
+           matrix.os == 'ubuntu-latest'
+           && contains(matrix.environment-file, 'DEV')
        
        - name: run tests - bash
          shell: bash -l {0}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,11 @@
  jobs:
    unittests:
      env:
-       RUN_TEST: pytest -v -n auto spaghetti --cov spaghetti --doctest-modules --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
+       RUN_TEST: |
+         pytest -v -n auto spaghetti \
+         --cov spaghetti --doctest-modules \
+         --cov-config .coveragerc --cov-report xml \
+         --color yes --cov-append --cov-report term-missing
        PIP_INSTALL: pip install git+https://github.com/pysal/
      name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
@@ -27,7 +31,13 @@
      strategy:
        matrix:
          os: [ubuntu-latest]
-         environment-file: [ci/37.yaml, ci/38.yaml, ci/39.yaml, ci/310.yaml, ci/310-BASE.yaml, ci/310-DEV.yaml]
+         environment-file:
+           - ci/37.yaml
+           - ci/38.yaml
+           - ci/39.yaml
+           - ci/310.yaml
+           - ci/310-BASE.yaml
+           - ci/310-DEV.yaml
          include:
            - environment-file: ci/310.yaml
              os: macos-latest

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,7 @@
  jobs:
    unittests:
      env:
-       RUN_TEST: pytest -v -n 4 spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
+       RUN_TEST: pytest -v -n auto spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report xml --color=yes --cov-append --cov-report term-missing
      name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,6 @@
  jobs:
    unittests:
      env:
-       PIP_INSTALL: pip install git+https://github.com/pysal/
        RUN_TEST: pytest -v -n auto spaghetti --cov spaghetti --doctest-modules --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
      name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
@@ -53,8 +52,8 @@
        - name: install bleeding edge libpysal & esda (Ubuntu / Python 3.10)
          shell: bash -l {0}
          run: |
-           ${{ env.PIP_INSTALL }}libpysal.git@master
-           ${{ env.PIP_INSTALL }}esda.git@master
+           pip install git+https://github.com/pysal/libpysal.git@master
+           pip install git+https://github.com/pysal/esda.git@master
          if: matrix.os == 'ubuntu-latest' && contains(matrix.environment-file, 'DEV')
        
        - name: run tests - bash

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,6 +20,7 @@
    unittests:
      env:
        RUN_TEST: pytest -v -n auto spaghetti --cov spaghetti --doctest-modules --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
+       PIP_INSTALL: pip install git+https://github.com/pysal/
      name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30
@@ -46,8 +47,8 @@
        - name: install bleeding edge libpysal & esda (only Ubuntu / Python 3.10)
          shell: bash -l {0}
          run: |
-           pip install git+https://github.com/pysal/libpysal.git@master
-           pip install git+https://github.com/pysal/esda.git@master
+           ${{ env.PIP_INSTALL }}libpysal.git@master
+           ${{ env.PIP_INSTALL }}esda.git@master
          if: matrix.os == 'ubuntu-latest' && contains(matrix.environment-file, 'DEV')
        
        - name: run tests - bash

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -18,6 +18,8 @@
 
  jobs:
    unittests:
+     env:
+       RUN_TEST: pytest -v -n 4 spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
      name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30
@@ -50,12 +52,12 @@
        
        - name: run tests - bash
          shell: bash -l {0}
-         run: pytest -v spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
+         run: env.RUN_TEST
          if: matrix.os != 'windows-latest'
        
        - name: run tests - powershell
          shell: powershell
-         run: pytest -v spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
+         run: env.RUN_TEST
          if: matrix.os == 'windows-latest'
        
        - name: codecov

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,7 @@
  jobs:
    unittests:
      env:
-       RUN_TEST: pytest -v -n auto spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
+       RUN_TEST: pytest -v -n 8 spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
      name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,7 @@
  jobs:
    unittests:
      env:
-       RUN_TEST: pytest -v -n 8 spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
+       RUN_TEST: pytest -v -n 4 spaghetti --cov=spaghetti --doctest-modules --cov-config=.coveragerc --cov-report=xml
      name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,13 +21,13 @@
      env:
        PIP_INSTALL: pip install git+https://github.com/pysal/
        RUN_TEST: pytest -v -n auto spaghetti --cov spaghetti --doctest-modules --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
-     name: ${{ matrix.os }}, ${{ matrix.env-file }}
+     name: ${{ matrix.os }}, ${{ matrix.environment-file }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30
      strategy:
        matrix:
          os: [ubuntu-latest]
-         env-file:
+         environment-file:
            - ci/37.yaml
            - ci/38.yaml
            - ci/39.yaml
@@ -35,9 +35,9 @@
            - ci/310-BASE.yaml
            - ci/310-DEV.yaml
          include:
-           - env-file: ci/310.yaml
+           - environment-file: ci/310.yaml
              os: macos-latest
-           - env-file: ci/310.yaml
+           - environment-file: ci/310.yaml
              os: windows-latest
      
      steps:
@@ -47,7 +47,7 @@
        - name: setup micromamba
          uses: mamba-org/provision-with-micromamba@main
          with:
-           env-file: ${{ matrix.env-file }}
+           environment-file: ${{ matrix.environment-file }}
            micromamba-version: 'latest'
       
        - name: install bleeding edge libpysal & esda (Ubuntu / Python 3.10)
@@ -55,7 +55,7 @@
          run: |
            ${{ env.PIP_INSTALL }}libpysal.git@master
            ${{ env.PIP_INSTALL }}esda.git@master
-         if: matrix.os == 'ubuntu-latest' && contains(matrix.env-file, 'DEV')
+         if: matrix.os == 'ubuntu-latest' && contains(matrix.environment-file, 'DEV')
        
        - name: run tests - bash
          shell: bash -l {0}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,18 +20,19 @@
    unittests:
      env:
        PIP_INSTALL: pip install git+https://github.com/pysal/
+       BRANCH: .git@master
        RUN_TEST: |
          pytest -v -n auto spaghetti \
          --cov spaghetti --doctest-modules \
          --cov-config .coveragerc --cov-report xml \
          --color yes --cov-append --cov-report term-missing
-     name: ${{ matrix.os }}, ${{ matrix.environment-file }}
+     name: ${{ matrix.os }}, ${{ matrix.env }}
      runs-on: ${{ matrix.os }}
      timeout-minutes: 30
      strategy:
        matrix:
          os: [ubuntu-latest]
-         environment-file:
+         env:
            - ci/37.yaml
            - ci/38.yaml
            - ci/39.yaml
@@ -39,9 +40,9 @@
            - ci/310-BASE.yaml
            - ci/310-DEV.yaml
          include:
-           - environment-file: ci/310.yaml
+           - env: ci/310.yaml
              os: macos-latest
-           - environment-file: ci/310.yaml
+           - env: ci/310.yaml
              os: windows-latest
      
      steps:
@@ -51,17 +52,15 @@
        - name: setup micromamba
          uses: mamba-org/provision-with-micromamba@main
          with:
-           environment-file: ${{ matrix.environment-file }}
+           env: ${{ matrix.env }}
            micromamba-version: 'latest'
       
        - name: install bleeding edge libpysal & esda (Ubuntu / Python 3.10)
          shell: bash -l {0}
          run: |
-           ${{ env.PIP_INSTALL }}libpysal.git@master
-           ${{ env.PIP_INSTALL }}esda.git@master
-         if: |
-           matrix.os == 'ubuntu-latest' \
-           && contains(matrix.environment-file, 'DEV')
+           ${{ env.PIP_INSTALL }}libpysal${{ env.BRANCH }}
+           ${{ env.PIP_INSTALL }}esda${{ env.BRANCH }}
+         if: matrix.os == 'ubuntu-latest' && contains(matrix.env, 'DEV')
        
        - name: run tests - bash
          shell: bash -l {0}

--- a/ci/310-BASE.yaml
+++ b/ci/310-BASE.yaml
@@ -17,3 +17,4 @@ dependencies:
   - codecov
   - pytest
   - pytest-cov
+  - pytest-xdist

--- a/ci/310-DEV.yaml
+++ b/ci/310-DEV.yaml
@@ -15,6 +15,7 @@ dependencies:
   - codecov
   - pytest
   - pytest-cov
+  - pytest-xdist
   # optional
   - geopandas>=0.9.0
   - pygeos>=0.8.0

--- a/ci/310.yaml
+++ b/ci/310.yaml
@@ -17,6 +17,7 @@ dependencies:
   - codecov
   - pytest
   - pytest-cov
+  - pytest-xdist
   # optional
   - geopandas>=0.7.0
   # for docs build action (this env only)

--- a/ci/37.yaml
+++ b/ci/37.yaml
@@ -17,5 +17,6 @@ dependencies:
   - codecov
   - pytest
   - pytest-cov
+  - pytest-xdist
   # optional
   - geopandas>=0.7.0

--- a/ci/38.yaml
+++ b/ci/38.yaml
@@ -17,5 +17,6 @@ dependencies:
   - codecov
   - pytest
   - pytest-cov
+  - pytest-xdist
   # optional
   - geopandas>=0.7.0

--- a/ci/39.yaml
+++ b/ci/39.yaml
@@ -17,6 +17,7 @@ dependencies:
   - codecov
   - pytest
   - pytest-cov
+  - pytest-xdist
   # optional
   - geopandas>=0.7.0
   # for docs build action (this env only)

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-cov
+pytest-xdist
 codecov
 twine
 wheel


### PR DESCRIPTION
This PR attempts to speed up CI by running tests on multiple cores with `pytest-xdist`. Locally I am seeing test runtime decrease from ~100 seconds to ~33 seconds. 