### PR TITLE
update black version in .pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos: 
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.12b0
     hooks: 
     - id: black
       language_version: python3.9


### PR DESCRIPTION
[As pointed out](https://github.com/pysal/libpysal/pull/451#discussion_r790254632) by @martinfleis we should be using the most recent version of `black` within the `.precommit-config.yml` hook. This is done by running `pre-commit autoupdate` locally. See this [comment](https://github.com/ljvmiranda921/comments.ljvmiranda921.github.io/issues/18#issuecomment-870697993).