### PR TITLE
swap master for main (libpysal)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -63,7 +63,7 @@
        - name: install bleeding edge libpysal & esda (Ubuntu / Python 3.11)
          shell: bash -l {0}
          run: |
-           pip install git+https://github.com/pysal/libpysal.git@master
+           pip install git+https://github.com/pysal/libpysal.git@main
            pip install git+https://github.com/pysal/esda.git@main
          if: matrix.os == 'ubuntu-latest' && contains(matrix.environment-file, 'DEV')
        


### PR DESCRIPTION
xref: https://github.com/pysal/inequality/pull/53

swap `libpysal@master` for `libpysal@main` in bleeding edge testing for resolve [current CI failures](https://github.com/pysal/spaghetti/actions/runs/4474340047/jobs/7862708353#step:4:14).