### PR TITLE
Doc patch

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,7 +13,7 @@ Network feature instantiation
 
 .. autosummary::
    :toctree: generated/
-    
+
     spaghetti.Network
     spaghetti.PointPattern
 
@@ -23,7 +23,7 @@ Network feature extraction and creation
 
 .. autosummary::
    :toctree: generated/
-    
+
     spaghetti.extract_component
     spaghetti.spanning_tree
     spaghetti.element_as_gdf
@@ -35,6 +35,6 @@ Save and load a network
 
 .. autosummary::
    :toctree: generated/
-    
-    spaghetti.Network.savenetwork
-    spaghetti.Network.loadnetwork
+
+    spaghetti.network.Network.savenetwork
+    spaghetti.network.Network.loadnetwork

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -257,7 +257,7 @@ intersphinx_mapping = {
     "networkx": ("https://networkx.org/documentation/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
-    "pointpats": ("https://pointpats.readthedocs.io/en/latest/", None),
+    "pointpats": ("https://pysal.org/pointpats/", None),
     "python": ("https://docs.python.org/3.11/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
 }


### PR DESCRIPTION
This is one option..

This would be the other:

```rst
.. currentmodule:: spaghetti.network

.. autosummary::
   :toctree: generated/

    Network.savenetwork
    Network.loadnetwork
```

I guess Python is not happy that we're trying to import a method from a class, not a module. Don't know.

Not adding a closing keyword for #731 as the result is not 1:1 as it used to be.