### PR TITLE
Utilize `ruff-format` over `black` for formatting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,11 +7,11 @@ Thank you for your interest in contributing! We work primarily on Github. Please
 
 1. All questions, comments, & discussions should happen in a public forum, where possible. Please start a [discussion](https://github.com/pysal/spaghetti/discussions) for questions or open an [issue](https://github.com/pysal/spaghetti/issues) if there appears to be a bug. Private messages and emails will not be answered in a substantive manner.
 
+
 ## Style and format
 
-1. Python 3.8, 3.9, 3.10, and 3.11 are the officially supported versions.
-2. This project follows the formatting conventions of [`black`](https://black.readthedocs.io/en/stable/) and utilizes [`pre-commit`](https://pre-commit.com) to format commits prior to pull requests being made. 
-    * LJ Miranda provides an [excellent, concise guide](https://ljvmiranda921.github.io/notebook/2018/06/21/precommits-using-black-and-flake8/) on setting up and implementing a `pre-commit` hook for `black`.
+1. At the time of this writing, Python 3.10, 3.11, and 3.12 are the officially supported versions.
+2. This project implements the linting and formatting conventions of [`ruff`](https://docs.astral.sh/ruff/) on all incoming Pull Requests. To ensure a PR is properly linted and formatted prior to creating a Pull Request, [install `pre-commit`](https://pre-commit.com/#installation) in your development environment and then [set up the `libpysal` configuration of pre-commit hooks](https://pre-commit.com/#3-install-the-git-hook-scripts). 
 3. Import packages, classes, and functions with their full name where possible.
   * For example:
     

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,10 @@
 files: "spaghetti\/"
 repos:
-  - repo: https://github.com/psf/black
-    rev: "23.11.0"
-    hooks:
-      - id: black
-        language_version: python3
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.1.6"
     hooks:
       - id: ruff
+      - id: ruff-format
 
 ci:
   autofix_prs: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ Repository = "https://github.com/pysal/spaghetti"
 
 [project.optional-dependencies]
 dev = [
-    "black",
     "ruff",
     "pre-commit",
 ]
@@ -81,33 +80,30 @@ include = [
     "spaghetti.*",
 ]
 
-[tool.black]
-line-length = 88
-extend-exclude = '''
-(
-  docs/conf.py
-)
-#'''
-
 [tool.ruff]
 line-length = 88
 select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]
-target-version = "py38"
-ignore = [
-    "B006",
-    "B008",
-    "B009",
-    "B010",
-    "C408",
-    "E731",
-    "F401",
-    "F403",
-    "N803",
-    "N806",
-    "N999",
-    "UP007"
-]
+target-version = "py310"
+#ignore = [
+#    "B006",
+#    "B008",
+#    "B009",
+#    "B010",
+#    "C408",
+#    "E731",
+#    "F401",
+#    "F403",
+#    "N803",
+#    "N806",
+#    "N999",
+#    "UP007"
+#]
 exclude = ["spaghetti/tests/*", "docs/*"]
+[tool.ruff.per-file-ignores]
+"*__init__.py" = [
+    "F401",  # imported but unused
+    "F403",  # star import; unable to detect undefined names
+]
 
 [tool.coverage.run]
 source = ["./spaghetti"]

--- a/spaghetti/network.py
+++ b/spaghetti/network.py
@@ -1,3 +1,5 @@
+# ruff: noqa: B009
+
 import contextlib
 import copy
 import os
@@ -283,7 +285,7 @@ class Network:
         extractgraph=True,
         w_components=True,
         weightings=False,
-        weights_kws=dict(),
+        weights_kws=dict(),  # noqa: B006, C408
         vertex_atol=None,
     ):
         # do this when creating a clean network instance from a
@@ -422,7 +424,7 @@ class Network:
         fully_connected = bool(n_components == 1)
 
         # link to component lookup
-        link2component = dict(zip(links, component_labels))
+        link2component = dict(zip(links, component_labels, strict=True))
 
         # component ID lookups: links, lengths, vertices, vertex counts
         component2link = {}
@@ -818,7 +820,11 @@ class Network:
         return nodes
 
     def contiguityweights(
-        self, graph=True, weightings=None, from_split=False, weights_kws=dict()
+        self,
+        graph=True,
+        weightings=None,
+        from_split=False,
+        weights_kws=dict(),  # noqa: B006, C408
     ):
         """Create a contiguity-based ``libpysal.weights.W`` object.
 
@@ -943,7 +949,11 @@ class Network:
         return w
 
     def distancebandweights(
-        self, threshold, n_processes=1, gen_tree=False, weights_kws=dict()
+        self,
+        threshold,
+        n_processes=1,
+        gen_tree=False,
+        weights_kws=dict(),  # noqa: B006, C408
     ):
         """Create distance-based weights.
 
@@ -2217,7 +2227,11 @@ class Network:
         return paths
 
     def split_arcs(
-        self, split_param, split_by="distance", w_components=True, weights_kws=dict()
+        self,
+        split_param,
+        split_by="distance",
+        w_components=True,
+        weights_kws=dict(),  # noqa: B006, C408
     ):
         """Split all network arcs at either a fixed distance or fixed count.
 
@@ -2816,12 +2830,12 @@ def extract_component(net, component_id, weightings=None):
             supp_name = [o + attr for o in obj]
             supp_lens = [getattr(cnet, s) for s in supp_name]
             supp_link = [getattr(cnet, o + "s") for o in obj]
-            supp_ll = list(zip(supp_lens, supp_link))
+            supp_ll = list(zip(supp_lens, supp_link, strict=True))
             _val = [{k: v for k, v in l1.items() if k in l2} for l1, l2 in supp_ll]
             attr = supp_name
 
         # reassign attributes
-        for a, av in zip(attr, _val):
+        for a, av in zip(attr, _val, strict=True):
             setattr(cnet, a, av)
 
     # provide warning (for now) if the network contains a point pattern

--- a/spaghetti/util.py
+++ b/spaghetti/util.py
@@ -393,7 +393,7 @@ def snap_points_to_links(points, links):
     # instantiate an rtree
     rtree = Rtree()
     # set the smallest possible float epsilon on machine
-    SMALL = numpy.finfo(float).eps
+    small = numpy.finfo(float).eps
 
     # initialize network vertex to link lookup
     vertex_2_link = {}
@@ -416,10 +416,10 @@ def snap_points_to_links(points, links):
 
         # minimally increase the bounding box exterior
         bx0, by0, bx1, by1 = link.bounding_box
-        bx0 -= SMALL
-        by0 -= SMALL
-        bx1 += SMALL
-        by1 += SMALL
+        bx0 -= small
+        by0 -= small
+        bx1 += small
+        by1 += small
 
         # insert the network link and its associated
         # rectangle into the rtree
@@ -456,7 +456,7 @@ def snap_points_to_links(points, links):
         #   https://github.com/pysal/spaghetti/issues/598
         #   https://github.com/pysal/spaghetti/pull/599
         candidates.sort(reverse=True)
-        dmin += SMALL
+        dmin += small
         dmin2 = dmin * dmin
 
         # of the candidate arcs, find the nearest to the query point
@@ -763,7 +763,7 @@ def _arcs_as_gdf(net, points, id_col=None):
         )
 
     # instantiate GeoDataFrame
-    arcs = pandas.DataFrame(zip(sorted(net.arcs)), columns=[id_col])
+    arcs = pandas.DataFrame(zip(sorted(net.arcs), strict=True), columns=[id_col])
     arcs = arcs.set_geometry(
         shapely.linestrings(arcs[id_col].map(_line_coords).values.tolist())
     )
@@ -799,7 +799,10 @@ def _routes_as_gdf(paths, id_col):
 
     # instantiate as a geodataframe
     paths = dict(paths)
-    ids, geoms = zip(paths.keys()), [LineString(g.vertices) for g in paths.values()]
+    ids, geoms = (
+        zip(paths.keys(), strict=True),
+        [LineString(g.vertices) for g in paths.values()],
+    )
     paths = geopandas.GeoDataFrame(ids, columns=[id_col], geometry=geoms)
 
     return paths


### PR DESCRIPTION
This PR follows up #751 by adopting `ruff-format` over `black` for formatting.

xref: https://github.com/pysal/libpysal/pull/662