### PR TITLE
pin max fiona in oldest CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 files: "spaghetti\/"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.5.0"
+    rev: "v0.6.5"
     hooks:
       - id: ruff
       - id: ruff-format

--- a/ci/310-oldest.yaml
+++ b/ci/310-oldest.yaml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.10
   # required
   - esda=2.1
+  - fiona<1.10
   - geopandas=0.12
   - libpysal=4.6
   - numpy=1.22


### PR DESCRIPTION
This PR:
* pins `fiona<1.10` in `py310-oldest` CI
* update `ruff` version in pre-commit
* xref https://github.com/pysal/pysal/issues/1356